### PR TITLE
fix: add table for outreach value per outreach type

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -47,6 +47,14 @@ Table countries {
   updatedAt DateTime [not null]
 }
 
+Table event_sizes {
+  id String [pk]
+  annualValue Int [not null]
+  type EventSizeType [not null]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+}
+
 Table event_reports {
   id String [pk]
   dariahCommissionedEvent String
@@ -95,6 +103,14 @@ Table outreach {
   countryId String
   country countries
   reports outreach_reports [not null]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+}
+
+Table outreach_type_values {
+  id String [pk]
+  annualValue Int [not null]
+  type OutreachType [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
 }
@@ -332,6 +348,12 @@ Enum CountryType {
   cooperating_partnership
   member_country
   other
+}
+
+Enum EventSizeType {
+  large
+  medium
+  small
 }
 
 Enum InstitutionType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -190,6 +190,18 @@ model Outreach {
   @@map(name: "outreach")
 }
 
+model OutreachTypeValue {
+  id String @id @default(uuid()) @db.Uuid
+
+  annualValue Int          @map(name: "annual_value")
+  type        OutreachType
+
+  createdAt DateTime @default(now()) @map(name: "created_at")
+  updatedAt DateTime @updatedAt @map(name: "updated_at")
+
+  @@map(name: "outreach_type_values")
+}
+
 model OutreachReport {
   id String @id @default(uuid()) @db.Uuid
 


### PR DESCRIPTION
this pr adds a new table to the data model for annual value per outreach type. this is used only for calculation.