### PR TITLE
feat: add pre-populated kpi fields

### DIFF
--- a/components/forms/outreach-reports-form-content.tsx
+++ b/components/forms/outreach-reports-form-content.tsx
@@ -6,6 +6,7 @@ import {
 	type Outreach,
 	type OutreachKpi,
 	OutreachKpiType,
+	type OutreachType,
 	type Prisma,
 	type Report,
 } from "@prisma/client";
@@ -68,7 +69,7 @@ export function OutreachReportsFormContent(props: OutreachReportsFormContentProp
 			<section className="grid gap-y-6">
 				{outreachs.map((outreach, index) => {
 					const outreachReport = outreachReportsByOutreachId.get(outreach.id);
-					const kpis = outreachReport?.kpis ?? [];
+					const kpis = outreachReport?.kpis;
 
 					return (
 						<Group key={outreach.id} className="grid content-start gap-y-6">
@@ -102,7 +103,7 @@ export function OutreachReportsFormContent(props: OutreachReportsFormContentProp
 								/>
 							</div>
 
-							<OutreachKpiList kpis={kpis} name={`outreachReports.${index}`} />
+							<OutreachKpiList kpis={kpis} name={`outreachReports.${index}`} outreachType={outreach.type} />
 
 							<hr />
 						</Group>
@@ -128,16 +129,17 @@ export function OutreachReportsFormContent(props: OutreachReportsFormContentProp
 }
 
 interface OutreachKpiListProps {
-	kpis: Array<OutreachKpi>;
+	kpis: Array<OutreachKpi> | undefined;
 	name: string;
+	outreachType: OutreachType
 }
 
 function OutreachKpiList(props: OutreachKpiListProps): ReactNode {
-	const { kpis: initialKpis, name: prefix } = props;
+	const { kpis: initialKpis, name: prefix, outreachType } = props;
 
 	const outreachKpiTypes = Object.values(OutreachKpiType);
 
-	const kpis = useListData<Partial<OutreachKpi> & { _id?: string }>({ initialItems: initialKpis });
+	const kpis = useListData<Partial<OutreachKpi> & { _id?: string }>({ initialItems: initialKpis ?? (outreachType === "national_website" ? defaultWebsiteOutreachKpis : defaultSocialMediaOutreachKpis ) });
 
 	return (
 		<div className="grid gap-y-6">
@@ -196,3 +198,16 @@ function OutreachKpiList(props: OutreachKpiListProps): ReactNode {
 		</div>
 	);
 }
+
+/** Pre-selected outreach kpis for "national_website" outreach type. */
+const defaultWebsiteOutreachKpis: Array<{ _id: string; unit: OutreachKpi["unit"] }> = [
+	{ _id: crypto.randomUUID(), unit: "page_views" },
+	{ _id: crypto.randomUUID(), unit: "unique_visitors" },
+];
+
+/** Pre-selected outreach kpis for "social_media" outreach type. */
+const defaultSocialMediaOutreachKpis: Array<{ _id: string; unit: OutreachKpi["unit"] }> = [
+	{ _id: crypto.randomUUID(), unit: "engagement" },
+	{ _id: crypto.randomUUID(), unit: "followers" },
+	{ _id: crypto.randomUUID(), unit: "impressions" },
+];

--- a/components/forms/service-reports-form-content.tsx
+++ b/components/forms/service-reports-form-content.tsx
@@ -8,7 +8,7 @@ import {
 	type Service,
 	type ServiceKpi,
 	ServiceKpiType,
-	ServiceStatus,
+	// ServiceStatus,
 } from "@prisma/client";
 import { useListData } from "@react-stately/data";
 import type { ReactNode } from "react";
@@ -56,7 +56,7 @@ export function ServiceReportsFormContent(props: ServiceReportsFormContentProps)
 		year,
 	} = props;
 
-	const serviceStatuses = Object.values(ServiceStatus);
+	// const serviceStatuses = Object.values(ServiceStatus);
 
 	const [formState, formAction] = useFormState(updateServiceReports, undefined);
 
@@ -77,7 +77,7 @@ export function ServiceReportsFormContent(props: ServiceReportsFormContentProps)
 			<section className="grid gap-y-6">
 				{services.map((service, index) => {
 					const serviceReport = serviceReportsByServiceId.get(service.id);
-					const kpis = serviceReport?.kpis ?? [];
+					const kpis = serviceReport?.kpis;
 
 					return (
 						<Group key={service.id} className="grid content-start gap-y-6">
@@ -146,7 +146,7 @@ export function ServiceReportsFormContent(props: ServiceReportsFormContentProps)
 }
 
 interface ServiceKpiListProps {
-	kpis: Array<ServiceKpi>;
+	kpis: Array<ServiceKpi> | undefined;
 	name: string;
 }
 
@@ -155,7 +155,9 @@ function ServiceKpiList(props: ServiceKpiListProps): ReactNode {
 
 	const serviceKpiTypes = Object.values(ServiceKpiType);
 
-	const kpis = useListData<Partial<ServiceKpi> & { _id?: string }>({ initialItems: initialKpis });
+	const kpis = useListData<Partial<ServiceKpi> & { _id?: string }>({
+		initialItems: initialKpis ?? defaultServiceKpis,
+	});
 
 	return (
 		<div className="grid gap-y-6">
@@ -214,3 +216,8 @@ function ServiceKpiList(props: ServiceKpiListProps): ReactNode {
 		</div>
 	);
 }
+
+/** Pre-selected service kpis. */
+const defaultServiceKpis: Array<{ _id: string; unit: ServiceKpi["unit"] }> = [
+	{ _id: crypto.randomUUID(), unit: "visits" },
+];


### PR DESCRIPTION
this pr pre-populates kpi fields for service and outreach, if none have been added before.