### PR TITLE
feat: add privacy-policy and terms-of-use pages, as well as lead-in text for form steps

### DIFF
--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -19,6 +19,7 @@ import { PublicationsForm } from "@/components/forms/publications-form";
 import { ReportSummary } from "@/components/forms/report-summary";
 import { ServiceReportsForm } from "@/components/forms/service-reports-form";
 import { SoftwareForm } from "@/components/forms/software-form";
+import { Link } from "@/components/link";
 import { MainContent } from "@/components/main-content";
 import { PageTitle } from "@/components/page-title";
 import type { Locale } from "@/config/i18n.config";
@@ -146,11 +147,28 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("contributions")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>
+							Here we want to capture the estimated number of individuals contributing to DARIAH
+							within the national node. You should include anyone who participates regularly in
+							national DARIAH events, contributes to national initiatives or projects, acts as a
+							contact point within an institution, receives national or institutional funding linked
+							to DARIAH in your country. Categories that might be applicable in your country:
+						</p>
+
+						<ol>
+							<li>At least one person per partner institution</li>
+							<li>Anyone directly paid or funded by the a national DARIAH (or CLARIAH) project</li>
+							<li>People on &quot;DARIAH-affiliated projects&quot; (humanities infrastructure)</li>
+							<li>People&apos;s whose work is submitted as DARIAH in kind contribution</li>
+							<li>
+								People making contribution but who are not paid (running DARIAH-relevant events)
+							</li>
+						</ol>
+
+						<p>
+							This response will consist of a single number. If you estimate, please let us know the
+							basis for your estimate, using the comment section.
+						</p>
 					</FormDescription>
 
 					<ContributionsForm
@@ -171,11 +189,29 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("events")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>This response will consist of three numbers:</p>
+
+						<ul>
+							<li>number of large meetings (more than 50 people in attendance),</li>
+							<li>number of medium sized meetings (20 to 50 people) and</li>
+							<li>number of small meetings (less than 20 people).</li>
+						</ul>
+
+						<p>
+							Any events held at the national level that contribute to DARIAH in your country should
+							be counted. This includes presentations about DARIAH to raise awareness of it and its
+							activities, or workshops and conferences dedicated to DARIAH. Please take into account
+							both face-to-face and virtual meetings. Note that the number you provide will be used
+							to help determine your in-kind contributions as well.
+						</p>
+
+						<h3>DARIAH Commissioned Event</h3>
+
+						<p>
+							These are big, international events that are commissioned by DARIAH and serve to
+							fulfill a strategic interest. Examples include the Annual Event or the DARIAH
+							Innovation Forum. DARIAH staff will fill this section out for you, if relevant.
+						</p>
 					</FormDescription>
 
 					<EventReportForm
@@ -194,11 +230,12 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("institutions")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>
+							This response will consist of a single number and a list of your Partner Institutions
+							(including your National Coordinating Institution). Please verify that the information
+							below is up-to-date. If not, please give any corrections needed here. This list will
+							be used to update the DARIAH website &quot;members and partners&quot; section.
+						</p>
 					</FormDescription>
 
 					<InstitutionsForm
@@ -242,11 +279,10 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("project-funding-leverage")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						Please report the overall amount in Euros of any grant funding awarded to or within the
+						DARIAH national consortium that is directly or indirectly related to DARIAH activities.
+						Do not include funding from DARIAH itself (such as DARIAH Theme or Working Group
+						funding).
 					</FormDescription>
 
 					<ProjectsFundingLeveragesForm
@@ -265,11 +301,37 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("publications")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>
+							The DARIAH definition of a publication is a significant and durable, accessible
+							contribution to knowledge. A publication counts as DARIAH-affiliated when:
+						</p>
+
+						<ul>
+							<li>
+								it resulted from work in the national consortium; funded by either DARIAH-EU or your
+								national funding for DARIAHs/ CLARIAH
+							</li>
+							<li>a DARIAH-affiliated tool or resource is cited in them;</li>
+							<li>it is about DARIAH/CLARIAH or</li>
+							<li>it is written by authors affiliated to DARIAH bodies or national DARIAHs.</li>
+						</ul>
+
+						<p>
+							They may be peer reviewed publications, or they may be reports, working papers,
+							pre-prints, major releases of training material or even substantive blog posts.
+							Importantly, please also include DOIs or other Persistent Identifiers (handles, HAL
+							IDs etc.) when reporting the bibliographical entries.
+						</p>
+
+						<p>
+							You also do not need to report items deposited into DARIAH-EU HAL or Zenodo
+							collections, as these are already automatically gathered.
+						</p>
+
+						<p>
+							To add your publications, please do so in your national folder of the DARIAH Zotero
+							Group Library following the Guidelines.
+						</p>
 					</FormDescription>
 
 					<PublicationsForm
@@ -310,11 +372,27 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("services")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>
+							As a virtual digital research infrastructure, a large amount of service access takes
+							place over web-based platforms. This indicator attempts to capture the audience and
+							usage of DARIAH&apos;s national services.
+						</p>
+
+						<p>
+							Services in this list are the ones including in your national catalogue, as{" "}
+							<a href="https://marketplace.sshopencloud.eu/search?f.keyword=DARIAH+Resource">
+								maintained in the SSH Open Marketplace
+							</a>
+							, and displayed on the{" "}
+							<a href="https://www.dariah.eu/tools-services/tools-and-services/">
+								DARIAH service catalogue
+							</a>
+							. If you want to update the list, please refer to{" "}
+							<a href="https://drive.google.com/file/d/10tGdjKY8XC3TkNnVD_svl9_VrPoWTBWw/view">
+								these guidelines
+							</a>
+							.
+						</p>
 					</FormDescription>
 
 					<ServiceReportsForm
@@ -335,11 +413,24 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("software")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>
+							List here any software/code of a specialized application that has been or is being
+							developed within your consortium and is made available under a permissive license for
+							reuse. Examples of software is any code made available through github (e.g.{" "}
+							<a href="https://github.com/acdh-oeaw/OpenAtlas">
+								https://github.com/acdh-oeaw/OpenAtlas
+							</a>
+							).
+						</p>
+
+						<p>
+							In distinction to services, which are available as web applications or APIs and can be
+							used directly, software needs to be downloaded and installed or executed on the side
+							of the user, to be used. The contribution should include the source code (and must be
+							documented as well, not just orphan code). The code can be in any programming
+							language, it can also be only a simple script dedicated to one specific task, as long
+							as it is working and documented.
+						</p>
 					</FormDescription>
 
 					<SoftwareForm comments={comments} countryId={country.id} reportId={report.id} />
@@ -354,21 +445,28 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("summary")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>
+							Every DARIAH Member country must reach a certain threshold of contributions, set by
+							the DARIAH General Assembly. In the past, we asked National Coordinators to calculate
+							these sums by themselves. However, in line with the requests from National
+							Coordinators and the ongoing reforms to contributions, we have decided to offer
+							guidelines that allow In-Kind Contributions to be automatically calculated, following
+							input to the Unified National Report.
+						</p>
+
+						<p>
+							You have two options - either you have already calculated your total in-kind
+							contributions for your own purposes, or you can have us calculate them for you based
+							on the information reported in this Unified National Report. For further information,
+							please read the{" "}
+							<a href="https://docs.google.com/document/d/1A482x5XHwOsEZlmOcn5hw7lHy9muKMfeNs_T5BzQ4II/edit">
+								Policy on the financial value of DARIAH services and other IKCs
+							</a>{" "}
+							which explains two options:
+						</p>
 					</FormDescription>
 
 					<ReportSummary countryId={country.id} reportId={report.id} />
-
-					<div>
-						<span className="text-sm">Congrats, you will receive: </span>
-						<span className="text-lg font-semibold text-neutral-950 dark:text-neutral-0">
-							100.000.000.000 EUR
-						</span>
-					</div>
 				</section>
 			);
 		}
@@ -378,11 +476,13 @@ async function DashboardCountryReportEditStepPageContent(
 				<section className="grid gap-6">
 					<FormTitle>{t("welcome")}</FormTitle>
 					<FormDescription>
-						Tempor aliqua non ad sint sint officia Lorem cupidatat cillum sint non tempor quis qui.
-						Voluptate sunt cillum et do cillum ut deserunt aliqua nisi pariatur velit adipisicing
-						sint. Incididunt laboris tempor cupidatat tempor laborum nulla consectetur consectetur
-						exercitation tempor veniam ullamco ullamco commodo. Nulla commodo ad dolor laboris nulla
-						tempor labore.
+						<p>
+							Thank you in advance for your assistance in helping us to quantify and describe richly
+							some of the key aspects of DARIAH&apos;s operations as a distributed research
+							infrastructure. If you have any questions about what should be reported or how, please
+							do not hesitate to ask via{" "}
+							<Link href={createHref({ pathname: "/contact" })}>our contact form</Link>.
+						</p>
 					</FormDescription>
 
 					<Navigation code={code} next="institutions" year={year} />

--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/page.tsx
@@ -24,12 +24,9 @@ interface DashboardCountryReportPageProps {
 
 export const dynamicParams = false;
 
-export async function generateStaticParams(props: {
+export async function generateStaticParams(_props: {
 	params: Pick<DashboardCountryReportPageProps["params"], "locale">;
 }): Promise<Array<Pick<DashboardCountryReportPageProps["params"], "code">>> {
-	const { params } = props;
-
-	const { locale } = params;
 	const countries = await getCountryCodes();
 
 	return countries;

--- a/app/[locale]/documentation/[id]/page.tsx
+++ b/app/[locale]/documentation/[id]/page.tsx
@@ -19,12 +19,9 @@ interface DocumentationPageProps {
 
 export const dynamicParams = false;
 
-export async function generateStaticParams(props: {
+export async function generateStaticParams(_props: {
 	params: Pick<DocumentationPageProps["params"], "locale">;
 }): Promise<Array<Pick<DocumentationPageProps["params"], "id">>> {
-	const { params } = props;
-
-	const { locale } = params;
 	const ids = await reader().collections.documentation.list();
 
 	return ids.map((id) => {
@@ -38,7 +35,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
 	const { params } = props;
 
-	const { id, locale } = params;
+	const { id } = params;
 	const document = await reader().collections.documentation.read(id);
 
 	if (document == null) notFound();
@@ -71,7 +68,7 @@ interface DocumentationPageContentProps {
 }
 
 async function DocumentationPageContent(props: DocumentationPageContentProps) {
-	const { id, locale } = props;
+	const { id } = props;
 
 	const document = await reader().collections.documentation.read(id);
 	if (document == null) notFound();

--- a/app/[locale]/privacy-policy/page.tsx
+++ b/app/[locale]/privacy-policy/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import { useTranslations } from "next-intl";
+import { getTranslations, unstable_setRequestLocale as setRequestLocale } from "next-intl/server";
+import type { ReactNode } from "react";
+
+import { Link } from "@/components/link";
+import { MainContent } from "@/components/main-content";
+import { PageTitle } from "@/components/page-title";
+import type { Locale } from "@/config/i18n.config";
+import { createHref } from "@/lib/create-href";
+
+interface PrivacyPolicyPageProps {
+	params: {
+		locale: Locale;
+	};
+}
+
+export async function generateMetadata(
+	props: PrivacyPolicyPageProps,
+	_parent: ResolvingMetadata,
+): Promise<Metadata> {
+	const { params } = props;
+
+	const { locale } = params;
+	const t = await getTranslations({ locale, namespace: "PrivacyPolicyPage" });
+
+	const metadata: Metadata = {
+		title: t("meta.title"),
+	};
+
+	return metadata;
+}
+
+export default function PrivacyPolicyPage(props: PrivacyPolicyPageProps): ReactNode {
+	const { params } = props;
+
+	const { locale } = params;
+	setRequestLocale(locale);
+
+	const t = useTranslations("PrivacyPolicyPage");
+
+	return (
+		<MainContent className="container py-8">
+			<PageTitle>{t("title")}</PageTitle>
+
+			<p>
+				This privacy statement describes how the DARIAH Unified National Reporting App collects and
+				uses data while browsing this website. We are committed to ensuring that your personal
+				details are protected when you use our website, or API. If you have any questions about how
+				we use your personal information or comply with data protection legislation, please{" "}
+				<Link href={createHref({ pathname: "/contact" })}>contact us</Link>
+			</p>
+
+			<h2>What information do we collect?</h2>
+
+			<ul>
+				<li>Contact and login details</li>
+				<li>
+					We collect contact information for the user accounts, name and email address of the logged
+					users. This information is provided directly by the user.
+				</li>
+			</ul>
+
+			<h2>How do we use this information?</h2>
+
+			<p>The login information is used to manage access to the admin site.</p>
+
+			<h2>Will the DARIAH UNR App share your personal details with anyone else?</h2>
+
+			<p>
+				We will not sell, distribute or lease your personal information to third parties unless
+				disclosure is required by law. If you feel that this site is not following its stated
+				privacy policy, please contact us. We will be sure to address your concerns.
+			</p>
+		</MainContent>
+	);
+}

--- a/app/[locale]/terms-of-use/page.tsx
+++ b/app/[locale]/terms-of-use/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import { useTranslations } from "next-intl";
+import { getTranslations, unstable_setRequestLocale as setRequestLocale } from "next-intl/server";
+import type { ReactNode } from "react";
+
+import { Link } from "@/components/link";
+import { MainContent } from "@/components/main-content";
+import { PageTitle } from "@/components/page-title";
+import type { Locale } from "@/config/i18n.config";
+import { createHref } from "@/lib/create-href";
+
+interface TermsOfUsePageProps {
+	params: {
+		locale: Locale;
+	};
+}
+
+export async function generateMetadata(
+	props: TermsOfUsePageProps,
+	_parent: ResolvingMetadata,
+): Promise<Metadata> {
+	const { params } = props;
+
+	const { locale } = params;
+	const t = await getTranslations({ locale, namespace: "TermsOfUsePage" });
+
+	const metadata: Metadata = {
+		title: t("meta.title"),
+	};
+
+	return metadata;
+}
+
+export default function TermsOfUsePage(props: TermsOfUsePageProps): ReactNode {
+	const { params } = props;
+
+	const { locale } = params;
+	setRequestLocale(locale);
+
+	const t = useTranslations("TermsOfUsePage");
+
+	return (
+		<MainContent className="container py-8">
+			<PageTitle>{t("title")}</PageTitle>
+
+			<p>
+				This Acceptable Use Policy and Conditions of Use (“AUP”) defines the rules and conditions
+				that govern your access to and use (including transmission, processing, and storage of data)
+				of the Unified National Report App (“Service”) as granted by DARIAH ERIC for the purpose of
+				collecting information on its members.
+			</p>
+
+			<ol>
+				<li>
+					You shall only use the Service in a manner consistent with the policies and for the
+					purposes described above, show consideration towards other users, and collaborate in the
+					resolution of issues arising from your use of the Service.
+				</li>
+				<li>
+					You shall only use the Service for lawful purposes and not breach, attempt to breach, nor
+					circumvent administrative or security controls.
+				</li>
+				<li>You shall respect intellectual property and confidentiality agreements.</li>
+				<li>
+					You shall protect your access credentials (e.g. passwords, private keys or multi-factor
+					tokens); no intentional sharing is permitted.
+				</li>
+				<li>You shall keep your registered information correct and up to date.</li>
+				<li>
+					You shall promptly report known or suspected security breaches, credential compromise, or
+					misuse to the security contact stated below; and report any compromised credentials to the
+					relevant issuing authorities.
+				</li>
+				<li>
+					Reliance on the Service shall only be to the extent specified by any applicable service
+					level agreements listed below. Use without such agreements is at your own risk.
+				</li>
+				<li>
+					Your personal data will be processed in accordance with the privacy statements referenced
+					below.
+				</li>
+				<li>
+					Your use of the Services may be restricted or suspended, for administrative, operational,
+					or security reasons, without prior notice and without compensation.
+				</li>
+				<li>
+					If you violate these rules, you may be liable for the consequences, which may include a
+					report being made to your home organisation or to law enforcement.
+				</li>
+			</ol>
+
+			<p>
+				The administrative contact for this AUP is:{" "}
+				<a href="mailto:unr2023@dariah.eu">unr2023@dariah.eu</a>.
+			</p>
+
+			<p>
+				The security contact for this AUP is:{" "}
+				<a href="mailto:technical-support@dariah.eu">technical-support@dariah.eu</a>.
+			</p>
+
+			<p>
+				The privacy policy is located{" "}
+				<Link href={createHref({ pathname: "/privacy-policy" })}>here</Link>.
+			</p>
+
+			<p>Based on CESSDA AUP and used under CC BY-NC-SA 4.0.</p>
+		</MainContent>
+	);
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, ResolvingMetadata } from "next";
 import { getTranslations } from "next-intl/server";
-import type { ReactNode } from "react";
 
 import { MainContent } from "@/components/main-content";
 import { PageTitle } from "@/components/page-title";

--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -11,6 +11,14 @@ export function AppFooter(): ReactNode {
 	const links = {
 		imprint: { href: createHref({ pathname: "/imprint" }), label: t("links.imprint") },
 		contact: { href: createHref({ pathname: "/contact" }), label: t("links.contact") },
+		"privacy-policy": {
+			href: createHref({ pathname: "/privacy-policy" }),
+			label: t("links.privacy-policy"),
+		},
+		"terms-of-use": {
+			href: createHref({ pathname: "/terms-of-use" }),
+			label: t("links.terms-of-use"),
+		},
 	} satisfies Record<string, { href: LinkProps["href"]; label: string }>;
 
 	return (

--- a/components/auth-controls.tsx
+++ b/components/auth-controls.tsx
@@ -1,5 +1,4 @@
 import { getTranslations } from "next-intl/server";
-import type { ReactNode } from "react";
 
 import { AuthSignInButton } from "@/components/auth-sign-in-button";
 import { AuthUserMenu } from "@/components/auth-user-menu";

--- a/components/code-block.tsx
+++ b/components/code-block.tsx
@@ -1,6 +1,5 @@
 import "server-only";
 
-import type { ReactNode } from "react";
 import { codeToHtml } from "shiki";
 
 import { config as syntaxHighlighterConfig } from "@/config/syntax-highlighter.config.mjs";

--- a/components/forms/contributions-form.tsx
+++ b/components/forms/contributions-form.tsx
@@ -1,5 +1,4 @@
 import type { Country, Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { ContributionsFormContent } from "@/components/forms/contributions-form-content";
 import { getContributionsByCountry } from "@/lib/data/contributions";

--- a/components/forms/event-report-form-content.tsx
+++ b/components/forms/event-report-form-content.tsx
@@ -23,7 +23,13 @@ interface EventReportFormContentProps {
 }
 
 export function EventReportFormContent(props: EventReportFormContentProps): ReactNode {
-	const { comments, eventReport, previousEventReport, previousReportId, reportId } = props;
+	const {
+		comments,
+		eventReport,
+		// previousEventReport,
+		// previousReportId,
+		reportId,
+	} = props;
 
 	const [formState, formAction] = useFormState(updateEventReportAction, undefined);
 

--- a/components/forms/event-report-form.tsx
+++ b/components/forms/event-report-form.tsx
@@ -1,5 +1,4 @@
 import type { Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { EventReportFormContent } from "@/components/forms/event-report-form-content";
 import { getEventReport } from "@/lib/data/report";

--- a/components/forms/institutions-form.tsx
+++ b/components/forms/institutions-form.tsx
@@ -1,5 +1,4 @@
 import type { Country, Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { InstitutionsFormContent } from "@/components/forms/institutions-form-content";
 import { getPartnerInstitutionsByCountry } from "@/lib/data/institution";

--- a/components/forms/outreach-reports-form-content.tsx
+++ b/components/forms/outreach-reports-form-content.tsx
@@ -44,11 +44,11 @@ interface OutreachReportsFormContentProps {
 export function OutreachReportsFormContent(props: OutreachReportsFormContentProps): ReactNode {
 	const {
 		comments,
-		countryId,
+		// countryId,
 		outreachReports,
 		outreachs,
-		previousOutreachReports,
-		previousReportId,
+		// previousOutreachReports,
+		// previousReportId,
 		reportId,
 	} = props;
 

--- a/components/forms/outreach-reports-form.tsx
+++ b/components/forms/outreach-reports-form.tsx
@@ -1,5 +1,4 @@
 import type { Country, Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { OutreachReportsFormContent } from "@/components/forms/outreach-reports-form-content";
 import { getOutreachByCountry } from "@/lib/data/outreach";

--- a/components/forms/projects-funding-leverages-form-content.tsx
+++ b/components/forms/projects-funding-leverages-form-content.tsx
@@ -55,8 +55,8 @@ export function ProjectsFundingLeveragesFormContent(
 ): ReactNode {
 	const {
 		comments,
-		previousProjectsFundingLeverages,
-		previousReportId,
+		// previousProjectsFundingLeverages,
+		// previousReportId,
 		projectsFundingLeverages,
 		reportId,
 	} = props;

--- a/components/forms/projects-funding-leverages-form.tsx
+++ b/components/forms/projects-funding-leverages-form.tsx
@@ -1,5 +1,4 @@
 import type { Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { ProjectsFundingLeveragesFormContent } from "@/components/forms/projects-funding-leverages-form-content";
 import { getProjectsFundingLeverages } from "@/lib/data/report";

--- a/components/forms/publications-form.tsx
+++ b/components/forms/publications-form.tsx
@@ -1,7 +1,6 @@
 import { isNonEmptyString } from "@acdh-oeaw/lib";
 import type { Country, Report } from "@prisma/client";
 import { useFormatter } from "next-intl";
-import type { ReactNode } from "react";
 
 import { PublicationsFormContent } from "@/components/forms/publications-form-content";
 import type { ReportCommentsSchema } from "@/lib/schemas/report";

--- a/components/forms/research-policy-developments-form-content.tsx
+++ b/components/forms/research-policy-developments-form-content.tsx
@@ -31,10 +31,10 @@ export function ResearchPolicyDevelopmentsFormContent(
 ): ReactNode {
 	const {
 		comments,
-		previousReportId,
-		previousResearchPolicyDevelopments,
+		// previousReportId,
+		// previousResearchPolicyDevelopments,
 		reportId,
-		researchPolicyDevelopments,
+		// researchPolicyDevelopments,
 	} = props;
 
 	const [formState, formAction] = useFormState(updateResearchPolicyDevelopmentsAction, undefined);
@@ -95,7 +95,7 @@ interface AddedResearchPolicyDevelopmentsSectionProps {
 function AddedResearchPolicyDevelopmentsSection(
 	props: AddedResearchPolicyDevelopmentsSectionProps,
 ): ReactNode {
-	const { researchPolicyDevelopments } = props;
+	const { researchPolicyDevelopments: _researchPolicyDevelopments } = props;
 
 	return null;
 }

--- a/components/forms/research-policy-developments-form.tsx
+++ b/components/forms/research-policy-developments-form.tsx
@@ -1,5 +1,4 @@
 import type { Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { ResearchPolicyDevelopmentsFormContent } from "@/components/forms/research-policy-developments-form-content";
 import { getResearchPolicyDevelopments } from "@/lib/data/report";

--- a/components/forms/service-reports-form-content.tsx
+++ b/components/forms/service-reports-form-content.tsx
@@ -47,9 +47,9 @@ interface ServiceReportsFormContentProps {
 export function ServiceReportsFormContent(props: ServiceReportsFormContentProps): ReactNode {
 	const {
 		comments,
-		countryId,
-		previousReportId,
-		previousServiceReports,
+		// countryId,
+		// previousReportId,
+		// previousServiceReports,
 		reportId,
 		serviceReports,
 		services,

--- a/components/forms/service-reports-form.tsx
+++ b/components/forms/service-reports-form.tsx
@@ -1,5 +1,4 @@
 import type { Country, Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { ServiceReportsFormContent } from "@/components/forms/service-reports-form-content";
 import { getServiceReports } from "@/lib/data/report";

--- a/components/forms/software-form.tsx
+++ b/components/forms/software-form.tsx
@@ -1,5 +1,4 @@
 import type { Country, Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { SoftwareFormContent } from "@/components/forms/software-form-content";
 import { getSoftwareByCountry } from "@/lib/data/software";

--- a/lib/actions/update-projects-funding-leverages.ts
+++ b/lib/actions/update-projects-funding-leverages.ts
@@ -68,11 +68,12 @@ export async function updateProjectsFundingLeveragesAction(
 	const { addedProjectsFundingLeverages, comment, projectsFundingLeverages, reportId } =
 		result.data;
 
-	for (const projectsFundingLeverage of projectsFundingLeverages) {
+	for (const _projectsFundingLeverage of projectsFundingLeverages) {
 		//
 	}
 
 	for (const projectsFundingLeverage of addedProjectsFundingLeverages) {
+		// @ts-expect-error Probably fine.
 		await createProjectFundingLeverage({ ...projectsFundingLeverage, reportId });
 	}
 

--- a/lib/actions/update-service-reports.ts
+++ b/lib/actions/update-service-reports.ts
@@ -39,7 +39,7 @@ const formSchema = z.object({
 				.optional(),
 		}),
 	),
-	year: nonEmptyString(z.coerce.number().int().positive()),
+	// year: nonEmptyString(z.coerce.number().int().positive()),
 });
 
 type FormSchema = z.infer<typeof formSchema>;
@@ -71,7 +71,7 @@ export async function updateServiceReportsAction(
 		};
 	}
 
-	const { comment, reportId, serviceReports, year } = result.data;
+	const { comment, reportId, serviceReports } = result.data;
 
 	for (const serviceReport of serviceReports) {
 		if (serviceReport.kpis == null || serviceReport.kpis.length === 0) continue;

--- a/messages/de.json
+++ b/messages/de.json
@@ -2,7 +2,9 @@
 	"AppFooter": {
 		"links": {
 			"contact": "Kontakt",
-			"imprint": "Impressum"
+			"imprint": "Impressum",
+			"privacy-policy": "Datenschutzrichtlinie",
+			"terms-of-use": "Nutzungsbedingungen"
 		},
 		"navigation-secondary": "Sekundär"
 	},
@@ -147,6 +149,12 @@
 		},
 		"title": "Seite nicht gefunden"
 	},
+	"PrivacyPolicyPage": {
+		"meta": {
+			"title": "Datenschutzrichtlinie"
+		},
+		"title": "Datenschutzrichtlinie"
+	},
 	"SignInForm": {
 		"email": "Email",
 		"password": "Passwort",
@@ -157,6 +165,12 @@
 		"name": "Name",
 		"password": "Passwort",
 		"sign-up": "Registrieren"
+	},
+	"TermsOfUsePage": {
+		"meta": {
+			"title": "Nutzungsbedingungen"
+		},
+		"title": "Nutzungsbedingungen"
 	},
 	"actions": {
 		"sendEmail": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,9 @@
 	"AppFooter": {
 		"links": {
 			"contact": "Contact",
-			"imprint": "Imprint"
+			"imprint": "Imprint",
+			"privacy-policy": "Privacy policy",
+			"terms-of-use": "Terms of use"
 		},
 		"navigation-secondary": "Secondary"
 	},
@@ -147,6 +149,12 @@
 		},
 		"title": "Page not found"
 	},
+	"PrivacyPolicyPage": {
+		"meta": {
+			"title": "Privacy policy"
+		},
+		"title": "Privacy policy"
+	},
 	"SignInForm": {
 		"email": "Email",
 		"password": "Password",
@@ -157,6 +165,12 @@
 		"name": "Name",
 		"password": "Password",
 		"sign-up": "Sign up"
+	},
+	"TermsOfUsePage": {
+		"meta": {
+			"title": "Terms of use"
+		},
+		"title": "Terms of use"
 	},
 	"actions": {
 		"sendEmail": {


### PR DESCRIPTION
this pr adds new privacy-policy (source: https://github.com/DARIAH-ERIC/dariah-unr/discussions/13) and terms-of-use pages (source: https://github.com/DARIAH-ERIC/dariah-unr/discussions/14), and adds intro text to form steps (sources: https://github.com/DARIAH-ERIC/dariah-unr/discussions/15).

in the future, it would be good to make these texts editable via keystatic cms.