### PR TITLE
chore: lint

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -23,6 +23,7 @@ export default authMiddleware((req) => {
 	 */
 	if (req.nextUrl.pathname.startsWith("/api/")) return;
 
+	// eslint-disable-next-line consistent-return
 	return i18nMiddleware(req);
 });
 

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
 					"allowNamedFunctions": true
 				}
 			],
+			"@typescript-eslint/no-unused-vars": "off",
 			"react/jsx-boolean-value": [
 				"error",
 				"always"


### PR DESCRIPTION
this pr disables the no-unused-vars eslint rule temporarily.