### PR TITLE
chore: pass unit test step when no tests are found

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
 	plugins: [tsConfigPaths()],
 	test: {
 		include: ["./test/**/*.test.ts"],
+		passWithNoTests: true,
 	},
 });


### PR DESCRIPTION
this pr adds the `passWithNoTests` config option to `vitest`.