### PR TITLE
ci: fix github token

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           registry: ${{ needs.env.outputs.registry }}
           username: ${{ github.actor }}
-          password: ${{ secrets.K8S_SECRET_GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
this fixes a typo in the github workflow which messed up the token.