### PR TITLE
ci: use alternative workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -128,7 +128,7 @@ jobs:
   deploy:
     name: Deploy docker image
     needs: [env, vars, build]
-    uses: dariah-eric/gl-autodevops-minimal-port/.github/workflows/deploy-cluster-2.yml@main
+    uses: dariah-eric/gl-autodevops-minimal-port/.github/workflows/deploy.yml@main
     secrets: inherit
     with:
       environment: "${{ needs.env.outputs.environment }}"


### PR DESCRIPTION
this switches the deployment ci/cd job to use a different workflow, which should be identical but depends on a different set on variables