### PR TITLE
fix: add report year to dynamic route params

### DIFF
--- a/.vscode/app.code-snippets
+++ b/.vscode/app.code-snippets
@@ -71,7 +71,7 @@
 			"\t};",
 			"}",
 			"",
-			"export const dynamicParams = false;",
+			"// export const dynamicParams = false;",
 			"",
 			"export async function generateStaticParams(props: {",
 			"\tparams: Pick<${1:Name}PageProps[\"params\"], \"locale\">;",

--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -28,6 +28,7 @@ import { createHref } from "@/lib/create-href";
 import { getCountryByCode, getCountryCodes as _getCountryCodes } from "@/lib/data/country";
 import { getReportByCountryCode } from "@/lib/data/report";
 import { getCountryCodes as getStaticCountryCodes } from "@/lib/get-country-codes";
+import { getReportYears } from "@/lib/get-report-years";
 import { redirect } from "@/lib/navigation";
 import {
 	type DashboardCountryReportEditStepPageParams,
@@ -45,23 +46,29 @@ interface DashboardCountryReportEditStepPageProps {
 	};
 }
 
-export const dynamicParams = false;
+// export const dynamicParams = false;
 
 export async function generateStaticParams(_props: {
 	params: Pick<DashboardCountryReportEditStepPageProps["params"], "locale">;
-}): Promise<Array<Pick<DashboardCountryReportEditStepPageProps["params"], "code" | "step">>> {
+}): Promise<
+	Array<Pick<DashboardCountryReportEditStepPageProps["params"], "code" | "step" | "year">>
+> {
 	/**
 	 * FIXME: we cannot access the postgres database on acdh servers from github ci/cd, so we cannot
-	 * query for country codes at build time.
+	 * query for country codes (or report years) at build time.
 	 */
 	// const countries = await getCountryCodes();
 	const countries = await Promise.resolve(Array.from(getStaticCountryCodes().values()));
 
 	const steps = dashboardCountryReportSteps;
 
-	const params = countries.flatMap((code) => {
-		return steps.map((step) => {
-			return { code, step };
+	const years = getReportYears();
+
+	const params = years.flatMap((year) => {
+		return countries.flatMap((code) => {
+			return steps.map((step) => {
+				return { code, step, year };
+			});
 		});
 	});
 

--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/page.tsx
@@ -12,6 +12,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { getCountryCodes as _getCountryCodes } from "@/lib/data/country";
 import { getReportByCountryCode } from "@/lib/data/report";
 import { getCountryCodes as getStaticCountryCodes } from "@/lib/get-country-codes";
+import { getReportYears } from "@/lib/get-report-years";
 import { redirect } from "@/lib/navigation";
 import { dashboardCountryReportPageParams } from "@/lib/schemas/dashboard";
 
@@ -23,20 +24,24 @@ interface DashboardCountryReportPageProps {
 	};
 }
 
-export const dynamicParams = false;
+// export const dynamicParams = false;
 
 export async function generateStaticParams(_props: {
 	params: Pick<DashboardCountryReportPageProps["params"], "locale">;
-}): Promise<Array<Pick<DashboardCountryReportPageProps["params"], "code">>> {
+}): Promise<Array<Pick<DashboardCountryReportPageProps["params"], "code" | "year">>> {
 	/**
 	 * FIXME: we cannot access the postgres database on acdh servers from github ci/cd, so we cannot
-	 * query for country codes at build time.
+	 * query for country codes (or report years) at build time.
 	 */
 	// const countries = await getCountryCodes();
 	const countries = await Promise.resolve(Array.from(getStaticCountryCodes().values()));
 
-	const params = countries.map((code) => {
-		return { code };
+	const years = getReportYears();
+
+	const params = years.flatMap((year) => {
+		return countries.map((code) => {
+			return { code, year };
+		});
 	});
 
 	return params;

--- a/app/[locale]/documentation/[id]/page.tsx
+++ b/app/[locale]/documentation/[id]/page.tsx
@@ -17,7 +17,7 @@ interface DocumentationPageProps {
 	};
 }
 
-export const dynamicParams = false;
+// export const dynamicParams = false;
 
 export async function generateStaticParams(_props: {
 	params: Pick<DocumentationPageProps["params"], "locale">;

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -26,7 +26,7 @@ interface LocaleLayoutProps {
 	};
 }
 
-export const dynamicParams = false;
+// export const dynamicParams = false;
 
 export function generateStaticParams(): Array<LocaleLayoutProps["params"]> {
 	return locales.map((locale) => {

--- a/lib/get-report-years.ts
+++ b/lib/get-report-years.ts
@@ -1,0 +1,7 @@
+import { range } from "@acdh-oeaw/lib";
+
+const years = range(2022, new Date().getUTCFullYear() - 1).map(String);
+
+export function getReportYears(): Array<string> {
+	return years;
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"setup": "is-ci || simple-git-hooks",
 		"start": "next start",
 		"test:db": "docker run -d -e POSTGRES_DB=dariah-unr-test -e POSTGRES_USER=dariah-unr-test -e POSTGRES_PASSWORD=dariah-unr-test --name dariah-unr-test -p 5432:5432 --rm postgres",
+		"test:db:init": "dotenv -c test -- run-s db:push db:ingest db:create-test-user db:create-report-year db:create-operational-cost-thresholds db:create-annual-values",
 		"test:db:push": "dotenv -c test -- prisma db push --force-reset",
 		"test:unit": "vitest run",
 		"test:unit:ui": "vitest run --ui",


### PR DESCRIPTION
this adds supported report years (from 2022 to the current year minus one, which represents the most recent reporting period) to dynamic route params. also disables `dynamicParams = false` for now, since the next.js behavior differs between dev and prod.