### PR TITLE
feat: add link to contact form to summary page

### DIFF
--- a/app/[locale]/contact/page.tsx
+++ b/app/[locale]/contact/page.tsx
@@ -8,11 +8,13 @@ import { MainContent } from "@/components/main-content";
 import { PageLeadIn } from "@/components/page-lead-in";
 import { PageTitle } from "@/components/page-title";
 import type { Locale } from "@/config/i18n.config";
+import { contactPageSearchParams } from "@/lib/schemas/email";
 
 interface ContactPageProps {
 	params: {
 		locale: Locale;
 	};
+	searchParams: Record<string, Array<string> | string>;
 }
 
 export async function generateMetadata(
@@ -32,19 +34,21 @@ export async function generateMetadata(
 }
 
 export default function ContactPage(props: ContactPageProps): ReactNode {
-	const { params } = props;
+	const { params, searchParams } = props;
 
 	const { locale } = params;
 	setRequestLocale(locale);
 
 	const t = useTranslations("ContactPage");
 
+	const contactSearchParams = contactPageSearchParams.parse(searchParams);
+
 	return (
 		<MainContent className="container grid max-w-screen-md content-start gap-8 py-8">
 			<PageTitle>{t("title")}</PageTitle>
 			<PageLeadIn>{t("lead-in")}</PageLeadIn>
 
-			<ContactForm />
+			<ContactForm {...contactSearchParams} />
 		</MainContent>
 	);
 }

--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -493,6 +493,8 @@ async function DashboardCountryReportEditStepPageContent(
 					</FormDescription>
 
 					<ReportSummary countryId={country.id} reportId={report.id} />
+
+					<Navigation code={code} previous="confirm" year={year} />
 				</section>
 			);
 		}

--- a/components/contact-form-content.tsx
+++ b/components/contact-form-content.tsx
@@ -10,8 +10,9 @@ import { Form } from "@/components/ui/form";
 import { FormError as FormErrorMessage } from "@/components/ui/form-error";
 import { FormSuccess as FormSuccessMessage } from "@/components/ui/form-success";
 import { sendContactEmail } from "@/lib/actions/contact";
+import type { ContactPageSearchParams } from "@/lib/schemas/email";
 
-interface ContactFormContentProps {
+interface ContactFormContentProps extends ContactPageSearchParams {
 	emailLabel: string;
 	messageLabel: string;
 	sendLabel: string;
@@ -19,7 +20,7 @@ interface ContactFormContentProps {
 }
 
 export function ContactFormContent(props: ContactFormContentProps): ReactNode {
-	const { emailLabel, messageLabel, sendLabel, subjectLabel } = props;
+	const { email, emailLabel, message, messageLabel, sendLabel, subject, subjectLabel } = props;
 
 	const [formState, formAction] = useFormState(sendContactEmail, undefined);
 
@@ -29,9 +30,9 @@ export function ContactFormContent(props: ContactFormContentProps): ReactNode {
 			className="grid gap-y-6"
 			validationErrors={formState?.status === "error" ? formState.fieldErrors : undefined}
 		>
-			<TextInputField label={emailLabel} name="email" type="email" />
-			<TextInputField label={subjectLabel} name="subject" />
-			<TextAreaField label={messageLabel} name="message" />
+			<TextInputField defaultValue={email} label={emailLabel} name="email" type="email" />
+			<TextInputField defaultValue={subject} label={subjectLabel} name="subject" />
+			<TextAreaField defaultValue={message} label={messageLabel} name="message" />
 
 			<SubmitButton>{sendLabel}</SubmitButton>
 

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -2,15 +2,23 @@ import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 
 import { ContactFormContent } from "@/components/contact-form-content";
+import type { ContactPageSearchParams } from "@/lib/schemas/email";
 
-export function ContactForm(): ReactNode {
+interface ContactFormProps extends ContactPageSearchParams {}
+
+export function ContactForm(props: ContactFormProps): ReactNode {
+	const { email, message, subject } = props;
+
 	const t = useTranslations("ContactForm");
 
 	return (
 		<ContactFormContent
+			email={email}
 			emailLabel={t("email")}
+			message={message}
 			messageLabel={t("message")}
 			sendLabel={t("send")}
+			subject={subject}
 			subjectLabel={t("subject")}
 		/>
 	);

--- a/components/forms/confirmation-form.tsx
+++ b/components/forms/confirmation-form.tsx
@@ -1,15 +1,24 @@
 import type { Country, Report } from "@prisma/client";
-import type { ReactNode } from "react";
 
 import { ConfirmationFormContent } from "@/components/forms/confirmation-form-content";
+import { Summary } from "@/components/forms/summary";
+import { calculateOperationalCost } from "@/lib/calculate-operational-cost";
 
 interface ConfirmationFormProps {
 	countryId: Country["id"];
 	reportId: Report["id"];
 }
 
-export function ConfirmationForm(props: ConfirmationFormProps): ReactNode {
+export async function ConfirmationForm(props: ConfirmationFormProps) {
 	const { countryId, reportId } = props;
 
-	return <ConfirmationFormContent countryId={countryId} reportId={reportId} />;
+	const calculation = await calculateOperationalCost({ countryId, reportId });
+
+	return (
+		<section className="grid gap-y-8">
+			<Summary calculation={calculation} />
+
+			<ConfirmationFormContent countryId={countryId} reportId={reportId} />
+		</section>
+	);
 }

--- a/components/forms/report-summary.tsx
+++ b/components/forms/report-summary.tsx
@@ -1,8 +1,11 @@
 import type { Country, Report } from "@prisma/client";
-import { useFormatter } from "next-intl";
 
 import { Confetti } from "@/components/confetti";
+import { Summary } from "@/components/forms/summary";
+import { Link } from "@/components/link";
+import { getCurrentUser } from "@/lib/auth/session";
 import { calculateOperationalCost } from "@/lib/calculate-operational-cost";
+import { createHref } from "@/lib/create-href";
 
 interface ReportSummaryProps {
 	countryId: Country["id"];
@@ -12,81 +15,41 @@ interface ReportSummaryProps {
 export async function ReportSummary(props: ReportSummaryProps) {
 	const { countryId, reportId } = props;
 
-	const { list } = useFormatter();
+	const user = await getCurrentUser();
 
 	const calculation = await calculateOperationalCost({ countryId, reportId });
 
+	const isAboveThreshold = calculation.operationalCost >= calculation.operationalCostThreshold;
+
 	return (
-		<section className="grid gap-y-8 text-sm">
-			<dl className="grid gap-y-4">
-				<div>
-					<dt>Number of partner institutions</dt>
-					<dd>{calculation.count.institutions}</dd>
-				</div>
+		<section className="grid gap-y-8">
+			<Summary calculation={calculation} />
 
-				<div>
-					<dt>Number of contributors at national level</dt>
-					<dd>{calculation.count.contributions}</dd>
-				</div>
-
-				<div>
-					<dt>Number of large meetings</dt>
-					<dd>{calculation.count.events.large}</dd>
-				</div>
-
-				<div>
-					<dt>Number of medium meetings</dt>
-					<dd>{calculation.count.events.medium}</dd>
-				</div>
-
-				<div>
-					<dt>Number of small meetings</dt>
-					<dd>{calculation.count.events.small}</dd>
-				</div>
-
-				<div>
-					<dt>Number of DARIAH commissioned events</dt>
-					<dd>{calculation.count.events.dariah}</dd>
-				</div>
-
-				<div>
-					<dt>National website</dt>
-					<dd>{list(calculation.url.website)}</dd>
-				</div>
-
-				<div>
-					<dt>National social media</dt>
-					<dd>{list(calculation.url.social)}</dd>
-				</div>
-
-				<div>
-					<dt>Number of small community services</dt>
-					<dd>{calculation.count.services.small}</dd>
-				</div>
-
-				<div>
-					<dt>Number of medium community services</dt>
-					<dd>{calculation.count.services.medium}</dd>
-				</div>
-
-				<div>
-					<dt>Number of large community services</dt>
-					<dd>{calculation.count.services.large}</dd>
-				</div>
-
-				<div>
-					<dt>Number of core community services</dt>
-					<dd>{calculation.count.services.core}</dd>
-				</div>
-			</dl>
-
-			<div className="grid gap-y-2 text-neutral-950 dark:text-neutral-0">
+			<div className="grid gap-y-2 text-sm text-neutral-950 dark:text-neutral-0">
 				<div>Financial value of the national in-kind contribution:</div>
 				<div>Threshold: {calculation.operationalCostThreshold}</div>
 				<div>Cost calculation: {calculation.operationalCost}</div>
 			</div>
 
-			<Confetti isEnabled={calculation.operationalCost >= calculation.operationalCostThreshold} />
+			<Confetti isEnabled={isAboveThreshold} />
+
+			{!isAboveThreshold ? (
+				<div>
+					If you want to get in touch about these numbers, please use our{" "}
+					<Link
+						href={createHref({
+							pathname: "/contact",
+							searchParams: {
+								email: user?.email,
+								subject: "Operational cost calculation",
+							},
+						})}
+					>
+						contact form
+					</Link>
+					.
+				</div>
+			) : null}
 		</section>
 	);
 }

--- a/components/forms/summary.tsx
+++ b/components/forms/summary.tsx
@@ -1,0 +1,102 @@
+import { useFormatter } from "next-intl";
+import type { ReactNode } from "react";
+
+import type { CalculateOperationalCostParamsResult } from "@/lib/calculate-operational-cost";
+
+interface SummaryProps {
+	calculation: CalculateOperationalCostParamsResult;
+}
+
+export function Summary(props: SummaryProps): ReactNode {
+	const { calculation } = props;
+
+	const { list } = useFormatter();
+
+	return (
+		<dl className="prose prose-sm grid gap-y-4">
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of partner institutions
+				</dt>
+				<dd>{calculation.count.institutions}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of contributors at national level
+				</dt>
+				<dd>{calculation.count.contributions}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of large meetings
+				</dt>
+				<dd>{calculation.count.events.large}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of medium meetings
+				</dt>
+				<dd>{calculation.count.events.medium}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of small meetings
+				</dt>
+				<dd>{calculation.count.events.small}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of DARIAH commissioned events
+				</dt>
+				<dd>{calculation.count.events.dariah}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					National website
+				</dt>
+				<dd>{list(calculation.url.website)}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					National social media
+				</dt>
+				<dd>{list(calculation.url.social)}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of small community services
+				</dt>
+				<dd>{calculation.count.services.small}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of medium community services
+				</dt>
+				<dd>{calculation.count.services.medium}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of large community services
+				</dt>
+				<dd>{calculation.count.services.large}</dd>
+			</div>
+
+			<div>
+				<dt className="text-xs uppercase tracking-wide text-neutral-600 dark:text-neutral-400">
+					Number of core community services
+				</dt>
+				<dd>{calculation.count.services.core}</dd>
+			</div>
+		</dl>
+	);
+}

--- a/lib/schemas/email.ts
+++ b/lib/schemas/email.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+export const contactPageSearchParams = z.object({
+	email: z.string().email().catch(""),
+	message: z.string().catch(""),
+	subject: z.string().catch(""),
+});
+
+export type ContactPageSearchParams = z.infer<typeof contactPageSearchParams>;
+
 export const contactFormSchema = z.object({
 	email: z.string().email(),
 	message: z.string(),


### PR DESCRIPTION
this adds a link to the contact form to the report summary page, allows navigating back to previous form steps from the summary page, and duplicates the report summary on the confirmation form step.