### PR TITLE
fix: display loading indicator between form steps

### DIFF
--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/loading.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/loading.tsx
@@ -1,0 +1,14 @@
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+
+import { MainContent } from "@/components/main-content";
+
+export default function Loading(): ReactNode {
+	const t = useTranslations("Loading");
+
+	return (
+		<MainContent className="container grid place-content-center py-8">
+			<div className="text-sm">{t("loading")}...</div>
+		</MainContent>
+	);
+}


### PR DESCRIPTION
this displays a loading indicator when navigating between form steps, because this sometimes can take a bit (e.g. the publications step fetches from zotero), so we should ensure the ui does not feel laggy.