### PR TITLE
feat: add previous year data to event report and contribution count help text

### DIFF
--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -192,6 +192,7 @@ async function DashboardCountryReportEditStepPageContent(
 						comments={comments}
 						contributionsCount={report.contributionsCount}
 						countryId={country.id}
+						previousContributionsCount={previousReport?.contributionsCount}
 						reportId={report.id}
 						year={year}
 					/>

--- a/components/forms/confirmation-form-content.tsx
+++ b/components/forms/confirmation-form-content.tsx
@@ -30,7 +30,7 @@ export function ConfirmationFormContent(props: ConfirmationFormContentProps): Re
 
 			<input name="reportId" type="hidden" value={reportId} />
 
-			<SubmitButton>Submit</SubmitButton>
+			<SubmitButton>Confirm</SubmitButton>
 
 			<FormSuccessMessage>
 				{formState?.status === "success" && formState.message.length > 0 ? formState.message : null}

--- a/components/forms/contributions-form-content.tsx
+++ b/components/forms/contributions-form-content.tsx
@@ -43,6 +43,7 @@ interface ContributionsFormContentProps {
 		}>
 	>;
 	contributionsCount: Report["contributionsCount"];
+	previousContributionsCount: Report["contributionsCount"] | undefined;
 	persons: Array<Pick<Person, "id" | "name">>;
 	reportId: Report["id"];
 	roles: Array<Pick<Role, "id" | "name">>;
@@ -57,6 +58,7 @@ export function ContributionsFormContent(props: ContributionsFormContentProps): 
 		contributions,
 		contributionsCount,
 		persons,
+		previousContributionsCount,
 		reportId,
 		roles,
 		workingGroups,
@@ -107,6 +109,11 @@ export function ContributionsFormContent(props: ContributionsFormContentProps): 
 
 			<NumberInputField
 				defaultValue={contributionsCount ?? undefined}
+				description={
+					previousContributionsCount != null
+						? `Previous year: ${previousContributionsCount}.`
+						: undefined
+				}
 				label="Total contributors to national node"
 				name="contributionsCount"
 			/>

--- a/components/forms/contributions-form.tsx
+++ b/components/forms/contributions-form.tsx
@@ -11,12 +11,14 @@ interface ContributionsFormProps {
 	comments: ReportCommentsSchema | null;
 	contributionsCount: Report["contributionsCount"];
 	countryId: Country["id"];
+	previousContributionsCount: Report["contributionsCount"] | undefined;
 	reportId: Report["id"];
 	year: number;
 }
 
 export async function ContributionsForm(props: ContributionsFormProps) {
-	const { comments, contributionsCount, countryId, reportId, year } = props;
+	const { comments, contributionsCount, countryId, previousContributionsCount, reportId, year } =
+		props;
 
 	const contributions = await getContributionsByCountry({ countryId });
 	const persons = await getPersonsByCountry({ countryId });
@@ -30,6 +32,7 @@ export async function ContributionsForm(props: ContributionsFormProps) {
 			contributionsCount={contributionsCount}
 			countryId={countryId}
 			persons={persons}
+			previousContributionsCount={previousContributionsCount}
 			reportId={reportId}
 			roles={roles}
 			workingGroups={workingGroups}

--- a/components/forms/event-report-form-content.tsx
+++ b/components/forms/event-report-form-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isNonEmptyString } from "@acdh-oeaw/lib";
 import type { EventReport, Report } from "@prisma/client";
 import type { ReactNode } from "react";
 import { useFormState } from "react-dom";
@@ -26,7 +27,7 @@ export function EventReportFormContent(props: EventReportFormContentProps): Reac
 	const {
 		comments,
 		eventReport,
-		// previousEventReport,
+		previousEventReport,
 		// previousReportId,
 		reportId,
 	} = props;
@@ -47,30 +48,56 @@ export function EventReportFormContent(props: EventReportFormContentProps): Reac
 
 			<TextInputField
 				defaultValue={eventReport?.dariahCommissionedEvent ?? undefined}
+				description={
+					previousEventReport != null &&
+					isNonEmptyString(previousEventReport.dariahCommissionedEvent)
+						? `Previous year: ${previousEventReport.dariahCommissionedEvent}.`
+						: undefined
+				}
 				label="DARIAH commissioned event"
 				name="eventReport.dariahCommissionedEvent"
 			/>
 
 			<NumberInputField
 				defaultValue={eventReport?.smallMeetings ?? undefined}
+				description={
+					previousEventReport != null
+						? `Previous year: ${previousEventReport.smallMeetings}.`
+						: undefined
+				}
 				label="Small meetings"
 				name="eventReport.smallMeetings"
 			/>
 
 			<NumberInputField
 				defaultValue={eventReport?.mediumMeetings ?? undefined}
+				description={
+					previousEventReport != null
+						? `Previous year: ${previousEventReport.mediumMeetings}.`
+						: undefined
+				}
 				label="Medium meetings"
 				name="eventReport.mediumMeetings"
 			/>
 
 			<NumberInputField
 				defaultValue={eventReport?.largeMeetings ?? undefined}
+				description={
+					previousEventReport != null
+						? `Previous year: ${previousEventReport.largeMeetings}.`
+						: undefined
+				}
 				label="Large meetings"
 				name="eventReport.largeMeetings"
 			/>
 
 			<TextInputField
 				defaultValue={eventReport?.reusableOutcomes ?? undefined}
+				description={
+					previousEventReport != null && isNonEmptyString(previousEventReport.reusableOutcomes)
+						? `Previous year: ${previousEventReport.reusableOutcomes}.`
+						: undefined
+				}
 				label="Reusable outcomes"
 				name="eventReport.reusableOutcomes"
 			/>


### PR DESCRIPTION
this adds help text to event report and contribution count fields, which indicates values filled in in the previous reporting period.