### PR TITLE
fix: trust host

### DIFF
--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -141,4 +141,5 @@ export const config = {
 	theme: {
 		logo: "/assets/images/logo.svg",
 	},
+	trustHost: true,
 } satisfies NextAuthConfig;


### PR DESCRIPTION
this sets `next-auth`'s `trustHost` setting to true, which should make `next-auth` use headers to correctly infer the hostname.