### PR TITLE
fix: don't use internal port for cms oauth

### DIFF
--- a/app/api/keystatic/[...params]/route.ts
+++ b/app/api/keystatic/[...params]/route.ts
@@ -18,6 +18,7 @@ function rewriteUrl(request: Request) {
 
 		url.hostname = forwardedHost;
 		url.protocol = forwardedProto;
+		url.port = "443";
 
 		return new Request(url, request);
 	}


### PR DESCRIPTION
this fixes the port being set to the internal 3000 for cms oauth redirect uri.