### PR TITLE
fix: ensure cms translations are available before cms loads

### DIFF
--- a/app/keystatic/layout.tsx
+++ b/app/keystatic/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import type { ReactNode } from "react";
+import { type ReactNode, Suspense } from "react";
 import { LocalizedStringProvider as Translations } from "react-aria-components/i18n";
 
 import KeystaticApp from "@/app/keystatic/keystatic";
@@ -17,7 +17,9 @@ export default function RootLayout(): ReactNode {
 		<html lang={locale}>
 			<body>
 				<Translations locale={locale} />
-				<KeystaticApp />
+				<Suspense>
+					<KeystaticApp />
+				</Suspense>
 			</body>
 		</html>
 	);


### PR DESCRIPTION
this ensures cms translations (via react-aria/i18n) are available before the cms starts loading.