### PR TITLE
fix: don't set input type number on react aria number input field

### DIFF
--- a/components/ui/number-input.tsx
+++ b/components/ui/number-input.tsx
@@ -21,7 +21,7 @@ export const NumberInput = forwardRef(function NumberInput(
 	const { children, className, ...rest } = props;
 
 	return (
-		<Input ref={forwardedRef} {...rest} className={numberInputStyles({ className })} type="number">
+		<Input ref={forwardedRef} {...rest} className={numberInputStyles({ className })}>
 			{children}
 		</Input>
 	);


### PR DESCRIPTION
this makes the number input a regular input field, because react-aria will manage validating input via js. setting the input type to "number" will lead to disappearing input for any value which needs a separator (i.e. above 999).