### PR TITLE
fix: add missing translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
 				"error",
 				"always"
 			],
+			"react/jsx-no-literals": "error",
 			"react/jsx-no-useless-fragment": "error",
 			"react/jsx-sort-props": [
 				"error",


### PR DESCRIPTION
this pr should add translations for all ui strings. for now, this only enables as lint plugin to more easily find ui string literals.