### PR TITLE
fix: ensure all server actions return timestamps

### DIFF
--- a/lib/actions/contact.ts
+++ b/lib/actions/contact.ts
@@ -10,11 +10,15 @@ import { type ContactFormSchema, contactFormSchema } from "@/lib/schemas/email";
 
 type FormSchema = ContactFormSchema;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -24,7 +28,7 @@ type FormState = FormErrors | FormSuccess;
 export async function sendContactEmail(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.sendEmail");
 
 	const input = getFormData(formData);
@@ -34,6 +38,7 @@ export async function sendContactEmail(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -46,5 +51,6 @@ export async function sendContactEmail(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-contribution-end-date.ts
+++ b/lib/actions/update-contribution-end-date.ts
@@ -15,11 +15,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -29,7 +33,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateContributionEndDateAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateContributionEndDate");
 
 	const input = getFormData(formData);
@@ -39,6 +43,7 @@ export async function updateContributionEndDateAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -52,5 +57,6 @@ export async function updateContributionEndDateAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-contributions.ts
+++ b/lib/actions/update-contributions.ts
@@ -34,11 +34,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -48,7 +52,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateContributionsAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateContributions");
 
 	const input = getFormData(formData);
@@ -58,6 +62,7 @@ export async function updateContributionsAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -81,5 +86,6 @@ export async function updateContributionsAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-event-report.ts
+++ b/lib/actions/update-event-report.ts
@@ -18,11 +18,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -32,7 +36,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateEventReportAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateEventReport");
 
 	const input = getFormData(formData);
@@ -42,6 +46,7 @@ export async function updateEventReportAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -57,6 +62,7 @@ export async function updateEventReportAction(
 
 	return {
 		status: "success" as const,
+		timestamp: Date.now(),
 		message: t("success"),
 	};
 }

--- a/lib/actions/update-institutions.ts
+++ b/lib/actions/update-institutions.ts
@@ -25,11 +25,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -39,7 +43,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateInstitutionsAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateInstitutions");
 
 	const input = getFormData(formData);
@@ -49,6 +53,7 @@ export async function updateInstitutionsAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -76,5 +81,6 @@ export async function updateInstitutionsAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-outreach-reports.ts
+++ b/lib/actions/update-outreach-reports.ts
@@ -61,7 +61,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateOutreachReportsAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateOutreachReports");
 
 	const input = getFormData(formData);

--- a/lib/actions/update-projects-funding-leverages.ts
+++ b/lib/actions/update-projects-funding-leverages.ts
@@ -41,11 +41,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -55,7 +59,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateProjectsFundingLeveragesAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateProjectsFundingLeverages");
 
 	const input = getFormData(formData);
@@ -65,6 +69,7 @@ export async function updateProjectsFundingLeveragesAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -95,5 +100,6 @@ export async function updateProjectsFundingLeveragesAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-publications.ts
+++ b/lib/actions/update-publications.ts
@@ -15,11 +15,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -29,7 +33,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updatePublicationsAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updatePublications");
 
 	const input = getFormData(formData);
@@ -39,6 +43,7 @@ export async function updatePublicationsAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -53,5 +58,6 @@ export async function updatePublicationsAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-report-status.ts
+++ b/lib/actions/update-report-status.ts
@@ -22,11 +22,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -36,7 +40,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateReportStatusAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateReport");
 
 	const input = getFormData(formData);
@@ -46,6 +50,7 @@ export async function updateReportStatusAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -70,5 +75,6 @@ export async function updateReportStatusAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-research-policy-developments.ts
+++ b/lib/actions/update-research-policy-developments.ts
@@ -15,11 +15,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -29,7 +33,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateResearchPolicyDevelopmentsAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateResearchPolicyDevelopments");
 
 	const input = getFormData(formData);
@@ -39,6 +43,7 @@ export async function updateResearchPolicyDevelopmentsAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -59,5 +64,6 @@ export async function updateResearchPolicyDevelopmentsAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }

--- a/lib/actions/update-service-reports.ts
+++ b/lib/actions/update-service-reports.ts
@@ -62,7 +62,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateServiceReportsAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateServiceReports");
 
 	const input = getFormData(formData);

--- a/lib/actions/update-software.ts
+++ b/lib/actions/update-software.ts
@@ -23,11 +23,15 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-interface FormErrors extends z.typeToFlattenedError<FormSchema> {
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<FormSchema> {
 	status: "error";
 }
 
-interface FormSuccess {
+interface FormSuccess extends FormReturnValue {
 	status: "success";
 	message: string;
 }
@@ -37,7 +41,7 @@ type FormState = FormErrors | FormSuccess;
 export async function updateSoftwareAction(
 	previousFormState: FormState | undefined,
 	formData: FormData,
-) {
+): Promise<FormState> {
 	const t = await getTranslations("actions.updateSoftware");
 
 	const input = getFormData(formData);
@@ -47,6 +51,7 @@ export async function updateSoftwareAction(
 		return {
 			status: "error" as const,
 			...result.error.flatten(),
+			timestamp: Date.now(),
 		};
 	}
 
@@ -70,5 +75,6 @@ export async function updateSoftwareAction(
 	return {
 		status: "success" as const,
 		message: t("success"),
+		timestamp: Date.now(),
 	};
 }


### PR DESCRIPTION
this ensures that all server actions return a timestamp, which can be used to invalidate client views (via `key`).