### PR TITLE
fix: use day granularity for day field

### DIFF
--- a/components/forms/projects-funding-leverages-form-content.tsx
+++ b/components/forms/projects-funding-leverages-form-content.tsx
@@ -98,6 +98,7 @@ export function ProjectsFundingLeveragesFormContent(
 										? parseAbsoluteToLocal(projectsFundingLeverage.startDate.toISOString())
 										: undefined
 								}
+								granularity="day"
 								isRequired={true}
 								label="Start date"
 								name={`projectsFundingLeverages.${index}.startDate`}


### PR DESCRIPTION
this uses "day" granularity for date fields, instead of displaying time and timezone as well.