### PR TITLE
fix: ensure responses have stable sort order

### DIFF
--- a/components/ui/form-error.tsx
+++ b/components/ui/form-error.tsx
@@ -2,6 +2,7 @@
 
 import { AlertCircleIcon } from "lucide-react";
 import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import { useFormStatus } from "react-dom";
 
 import { type ForwardedRef, forwardRef } from "@/lib/forward-ref";
 import { type VariantProps, variants } from "@/lib/styles";
@@ -31,7 +32,12 @@ export const FormError = forwardRef(function FormError(
 ) {
 	const { children, className, ...rest } = props;
 
-	const isEmpty = children == null;
+	/** TODO: Consider moving up a level once `useActionState` lands in `react`. */
+	const { pending } = useFormStatus();
+
+	/** Clear message when form submission is in flight. */
+	const message = pending ? null : children;
+	const isEmpty = message == null;
 
 	return (
 		<div
@@ -43,7 +49,7 @@ export const FormError = forwardRef(function FormError(
 			className={formErrorStyles({ className, isEmpty })}
 		>
 			{!isEmpty ? <AlertCircleIcon aria-hidden={true} className="size-4 shrink-0" /> : null}
-			{children}
+			{message}
 		</div>
 	);
 });

--- a/components/ui/form-success.tsx
+++ b/components/ui/form-success.tsx
@@ -2,6 +2,7 @@
 
 import { CheckIcon } from "lucide-react";
 import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import { useFormStatus } from "react-dom";
 
 import { type ForwardedRef, forwardRef } from "@/lib/forward-ref";
 import { type VariantProps, variants } from "@/lib/styles";
@@ -31,7 +32,12 @@ export const FormSuccess = forwardRef(function FormSuccess(
 ) {
 	const { children, className, ...rest } = props;
 
-	const isEmpty = children == null;
+	/** TODO: Consider moving up a level once `useActionState` lands in `react`. */
+	const { pending } = useFormStatus();
+
+	/** Clear message when form submission is in flight. */
+	const message = pending ? null : children;
+	const isEmpty = message == null;
 
 	return (
 		<div
@@ -43,7 +49,7 @@ export const FormSuccess = forwardRef(function FormSuccess(
 			className={formSuccessStyles({ className, isEmpty })}
 		>
 			{!isEmpty ? <CheckIcon aria-hidden={true} className="size-4 shrink-0" /> : null}
-			{children}
+			{message}
 		</div>
 	);
 });

--- a/lib/data/contributions.ts
+++ b/lib/data/contributions.ts
@@ -16,6 +16,9 @@ export function getContributionsByCountry(params: GetContributionsByCountryParam
 			},
 			endDate: null,
 		},
+		orderBy: {
+			startDate: "asc",
+		},
 		include: {
 			person: {
 				select: {

--- a/lib/data/country.ts
+++ b/lib/data/country.ts
@@ -4,6 +4,9 @@ import { db } from "@/lib/db";
 
 export function getCountryCodes() {
 	return db.country.findMany({
+		orderBy: {
+			code: "asc",
+		},
 		select: {
 			code: true,
 		},
@@ -34,6 +37,14 @@ export function getCountryById(params: GetCountryByIdParams) {
 	return db.country.findFirst({
 		where: {
 			id,
+		},
+	});
+}
+
+export function getCountries() {
+	return db.country.findMany({
+		orderBy: {
+			code: "asc",
 		},
 	});
 }

--- a/lib/data/institution.ts
+++ b/lib/data/institution.ts
@@ -18,6 +18,9 @@ export function getInstitutionsByCountry(params: GetPartnerInstitutionsByCountry
 			},
 			endDate: null,
 		},
+		orderBy: {
+			name: "asc",
+		},
 	});
 }
 
@@ -39,6 +42,9 @@ export function getPartnerInstitutionsByCountry(params: GetPartnerInstitutionsBy
 			types: {
 				has: InstitutionType.partner_institution,
 			},
+		},
+		orderBy: {
+			name: "asc",
 		},
 	});
 }

--- a/lib/data/outreach.ts
+++ b/lib/data/outreach.ts
@@ -16,6 +16,9 @@ export function getOutreachByCountry(params: GetOutreachByCountryParams) {
 			},
 			endDate: null,
 		},
+		orderBy: {
+			name: "asc",
+		},
 	});
 }
 
@@ -32,6 +35,9 @@ export function getOutreachUrlsByCountry(params: GetOutreachUrlsByCountryParams)
 				id: countryId,
 			},
 			endDate: null,
+		},
+		orderBy: {
+			name: "asc",
 		},
 		select: {
 			type: true,
@@ -54,6 +60,9 @@ export function getSocialMediaByCountry(params: GetSocialMediaByCountryParams) {
 			},
 			endDate: null,
 			type: "social_media",
+		},
+		orderBy: {
+			name: "asc",
 		},
 		select: {
 			url: true,

--- a/lib/data/person.ts
+++ b/lib/data/person.ts
@@ -21,6 +21,9 @@ export function getPersonsByCountry(params: GetPersonsByCountryParams) {
 				},
 			},
 		},
+		orderBy: {
+			name: "asc",
+		},
 		select: {
 			id: true,
 			name: true,

--- a/lib/data/report.ts
+++ b/lib/data/report.ts
@@ -133,6 +133,9 @@ export function getOutreachReports(params: GetOutreachReportsParams) {
 				id: reportId,
 			},
 		},
+		orderBy: {
+			createdAt: "asc",
+		},
 		include: {
 			kpis: true,
 			outreach: true,
@@ -153,6 +156,9 @@ export function getProjectsFundingLeverages(params: GetProjectsFundingLeveragesP
 				id: reportId,
 			},
 		},
+		orderBy: {
+			createdAt: "asc",
+		},
 	});
 }
 
@@ -168,6 +174,9 @@ export function getResearchPolicyDevelopments(params: GetResearchPolicyDevelopme
 			report: {
 				id: reportId,
 			},
+		},
+		orderBy: {
+			createdAt: "asc",
 		},
 	});
 }
@@ -187,6 +196,9 @@ export function getServiceReports(params: GetServiceReportsParams) {
 			service: {
 				status: "live",
 			},
+		},
+		orderBy: {
+			createdAt: "asc",
 		},
 		include: {
 			kpis: true,
@@ -445,6 +457,9 @@ export function updateReportContributionsCount(params: UpdateReportContributions
 
 export function getEventSizes() {
 	return db.eventSize.findMany({
+		orderBy: {
+			type: "asc",
+		},
 		select: {
 			annualValue: true,
 			id: true,
@@ -455,6 +470,9 @@ export function getEventSizes() {
 
 export function getOutreachTypeValues() {
 	return db.outreachTypeValue.findMany({
+		orderBy: {
+			type: "asc",
+		},
 		select: {
 			annualValue: true,
 			id: true,

--- a/lib/data/role.ts
+++ b/lib/data/role.ts
@@ -2,6 +2,9 @@ import { db } from "@/lib/db";
 
 export function getRoles() {
 	return db.role.findMany({
+		orderBy: {
+			name: "asc",
+		},
 		select: {
 			annualValue: true,
 			id: true,

--- a/lib/data/service.ts
+++ b/lib/data/service.ts
@@ -20,6 +20,9 @@ export function getServicesByCountry(params: GetServicesByCountryParams) {
 				not: "discontinued",
 			},
 		},
+		orderBy: {
+			name: "asc",
+		},
 		include: {
 			size: true,
 		},
@@ -28,6 +31,9 @@ export function getServicesByCountry(params: GetServicesByCountryParams) {
 
 export function getServiceSizes() {
 	return db.serviceSize.findMany({
+		orderBy: {
+			type: "asc",
+		},
 		select: {
 			annualValue: true,
 			id: true,

--- a/lib/data/software.ts
+++ b/lib/data/software.ts
@@ -20,6 +20,9 @@ export function getSoftwareByCountry(params: GetSoftwareByCountryParams) {
 				not: "not_maintained",
 			},
 		},
+		orderBy: {
+			name: "asc",
+		},
 	});
 }
 

--- a/lib/data/user.ts
+++ b/lib/data/user.ts
@@ -33,3 +33,11 @@ export async function createUser(params: CreateUserByEmailParams) {
 		},
 	});
 }
+
+export function getUsers() {
+	return db.user.findMany({
+		orderBy: {
+			name: "asc",
+		},
+	});
+}

--- a/lib/data/working-group.ts
+++ b/lib/data/working-group.ts
@@ -2,6 +2,9 @@ import { db } from "@/lib/db";
 
 export function getWorkingGroups() {
 	return db.workingGroup.findMany({
+		orderBy: {
+			name: "asc",
+		},
 		select: {
 			id: true,
 			name: true,


### PR DESCRIPTION
this adds an explicit sort order to all `findMany` queries. note that we currently don't add any additional db indices.