### PR TITLE
feat: add national coordinator user role

### DIFF
--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -144,6 +144,8 @@ async function DashboardCountryReportEditStepPageContent(
 
 	const previousReport = await getReportByCountryCode({ countryCode: code, year: year - 1 });
 
+	const isConfirmationAvailable = user.role === "admin" || user.role === "national_coordinator";
+
 	switch (step) {
 		case "confirm": {
 			return (
@@ -157,7 +159,11 @@ async function DashboardCountryReportEditStepPageContent(
 					</FormDescription>
 
 					<FormPlaceholder>
-						<ConfirmationForm countryId={country.id} reportId={report.id} />
+						<ConfirmationForm
+							countryId={country.id}
+							isConfirmationAvailable={isConfirmationAvailable}
+							reportId={report.id}
+						/>
 					</FormPlaceholder>
 
 					<Navigation code={code} next="summary" previous="project-funding-leverage" year={year} />

--- a/components/forms/confirmation-form-content.tsx
+++ b/components/forms/confirmation-form-content.tsx
@@ -13,11 +13,12 @@ import { createKey } from "@/lib/create-key";
 
 interface ConfirmationFormContentProps {
 	countryId: Country["id"];
+	isConfirmationAvailable: boolean;
 	reportId: Report["id"];
 }
 
 export function ConfirmationFormContent(props: ConfirmationFormContentProps): ReactNode {
-	const { countryId, reportId } = props;
+	const { countryId, isConfirmationAvailable, reportId } = props;
 
 	const [formState, formAction] = useFormState(updateReportStatusAction, undefined);
 
@@ -31,7 +32,9 @@ export function ConfirmationFormContent(props: ConfirmationFormContentProps): Re
 
 			<input name="reportId" type="hidden" value={reportId} />
 
-			<SubmitButton>Confirm</SubmitButton>
+			<SubmitButton isDisabled={!isConfirmationAvailable}>
+				{isConfirmationAvailable ? "Confirm" : "Only national coordinators can submit confirmation"}
+			</SubmitButton>
 
 			<FormSuccessMessage key={createKey("form-success", formState?.timestamp)}>
 				{formState?.status === "success" && formState.message.length > 0 ? formState.message : null}

--- a/components/forms/confirmation-form.tsx
+++ b/components/forms/confirmation-form.tsx
@@ -6,11 +6,12 @@ import { calculateOperationalCost } from "@/lib/calculate-operational-cost";
 
 interface ConfirmationFormProps {
 	countryId: Country["id"];
+	isConfirmationAvailable: boolean;
 	reportId: Report["id"];
 }
 
 export async function ConfirmationForm(props: ConfirmationFormProps) {
-	const { countryId, reportId } = props;
+	const { countryId, isConfirmationAvailable, reportId } = props;
 
 	const calculation = await calculateOperationalCost({ countryId, reportId });
 
@@ -18,7 +19,11 @@ export async function ConfirmationForm(props: ConfirmationFormProps) {
 		<section className="grid gap-y-8">
 			<Summary calculation={calculation} />
 
-			<ConfirmationFormContent countryId={countryId} reportId={reportId} />
+			<ConfirmationFormContent
+				countryId={countryId}
+				isConfirmationAvailable={isConfirmationAvailable}
+				reportId={reportId}
+			/>
 		</section>
 	);
 }

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -477,6 +477,7 @@ Enum SoftwareStatus {
 Enum UserRole {
   admin
   contributor
+  national_coordinator
 }
 
 Enum UserStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -600,6 +600,7 @@ model Account {
 enum UserRole {
   admin
   contributor
+  national_coordinator
 }
 
 enum UserStatus {


### PR DESCRIPTION
this adds a new "national coordinator" user role, and disables the confirmation submit button for users with role "contributor".