### PR TITLE
fix: use new outreach name column in baserow ingest

### DIFF
--- a/prisma/ingest.ts
+++ b/prisma/ingest.ts
@@ -164,8 +164,7 @@ async function ingest() {
 		const type = getEnumValue<any>(row["channel type"]?.value);
 		const record = await db.outreach.create({
 			data: {
-				/** There is no `name` field in the baserow database, so we duplicate `url`. */
-				name: row["Website or channel"],
+				name: row["name of the outreach channel"],
 				type: type,
 				url: row["Website or channel"],
 				country,


### PR DESCRIPTION
this uses the recently added "outreach name" column when ingesting data from baserow, instead of copying the url field.