### PR TITLE
fix: make add-software button link to ssh open marketplace

### DIFF
--- a/components/forms/service-reports-form-content.tsx
+++ b/components/forms/service-reports-form-content.tsx
@@ -42,6 +42,7 @@ interface ServiceReportsFormContentProps {
 	reportId: Report["id"];
 	serviceReports: Array<ServiceReportWithKpis>;
 	services: Array<Service>;
+	sshompBaseUrl: string;
 	year: number;
 }
 
@@ -54,6 +55,7 @@ export function ServiceReportsFormContent(props: ServiceReportsFormContentProps)
 		reportId,
 		serviceReports,
 		services,
+		sshompBaseUrl,
 		year,
 	} = props;
 
@@ -119,7 +121,7 @@ export function ServiceReportsFormContent(props: ServiceReportsFormContentProps)
 			<div className="flex items-center gap-x-2">
 				<LinkButton
 					href={createHref({
-						baseUrl: "https://marketplace.sshopencloud.eu",
+						baseUrl: sshompBaseUrl,
 						pathname: "/tool-or-service/new",
 					})}
 					target="_blank"

--- a/components/forms/service-reports-form.tsx
+++ b/components/forms/service-reports-form.tsx
@@ -1,6 +1,7 @@
 import type { Country, Report } from "@prisma/client";
 
 import { ServiceReportsFormContent } from "@/components/forms/service-reports-form-content";
+import { env } from "@/config/env.config";
 import { getServiceReports } from "@/lib/data/report";
 import { getServicesByCountry } from "@/lib/data/service";
 import type { ReportCommentsSchema } from "@/lib/schemas/report";
@@ -31,6 +32,7 @@ export async function ServiceReportsForm(props: ServiceReportsFormProps) {
 			reportId={reportId}
 			serviceReports={serviceReports}
 			services={services}
+			sshompBaseUrl={env.SSHOC_MARKETPLACE_BASE_URL}
 			year={year}
 		/>
 	);

--- a/components/forms/software-form.tsx
+++ b/components/forms/software-form.tsx
@@ -1,6 +1,7 @@
 import type { Country, Report } from "@prisma/client";
 
 import { SoftwareFormContent } from "@/components/forms/software-form-content";
+import { env } from "@/config/env.config";
 import { getSoftwareByCountry } from "@/lib/data/software";
 import type { ReportCommentsSchema } from "@/lib/schemas/report";
 
@@ -21,6 +22,7 @@ export async function SoftwareForm(props: SoftwareFormProps) {
 			countryId={countryId}
 			reportId={reportId}
 			softwares={softwares}
+			sshompBaseUrl={env.SSHOC_MARKETPLACE_BASE_URL}
 		/>
 	);
 }


### PR DESCRIPTION
this makes the add-software button link to ssh open marketplace, mirroring the behavior on the service-report page.

the source of truth for both software and services is the sshomp.