### PR TITLE
feat: add dashboard button to ingest data from ssh open marketplace

### DIFF
--- a/app/[locale]/dashboard/admin/page.tsx
+++ b/app/[locale]/dashboard/admin/page.tsx
@@ -60,6 +60,11 @@ function DashboardAdminPageContent() {
 						Edit institutions
 					</Link>
 				</li>
+				<li>
+					<Link href={createHref({ pathname: "/dashboard/admin/sshomp" })}>
+						Ingest software and services from SSH Open Marketplace
+					</Link>
+				</li>
 			</ul>
 		</section>
 	);

--- a/app/[locale]/dashboard/admin/sshomp/page.tsx
+++ b/app/[locale]/dashboard/admin/sshomp/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import { useTranslations } from "next-intl";
+import { getTranslations, unstable_setRequestLocale as setRequestLocale } from "next-intl/server";
+import type { ReactNode } from "react";
+
+import { AdminSshompIngestFormContent } from "@/components/admin/sshomp-ingest-form-content";
+import { MainContent } from "@/components/main-content";
+import { PageTitle } from "@/components/page-title";
+import type { Locale } from "@/config/i18n.config";
+
+interface DashboardAdminSshompIngestPageProps {
+	params: {
+		locale: Locale;
+	};
+}
+
+export async function generateMetadata(
+	props: DashboardAdminSshompIngestPageProps,
+	_parent: ResolvingMetadata,
+): Promise<Metadata> {
+	const { params } = props;
+
+	const { locale } = params;
+	const t = await getTranslations({ locale, namespace: "DashboardAdminSshompIngestPage" });
+
+	const metadata: Metadata = {
+		title: t("meta.title"),
+	};
+
+	return metadata;
+}
+
+export default function DashboardAdminSshompIngestPage(
+	props: DashboardAdminSshompIngestPageProps,
+): ReactNode {
+	const { params } = props;
+
+	const { locale } = params;
+	setRequestLocale(locale);
+
+	const t = useTranslations("DashboardAdminSshompIngestPage");
+
+	return (
+		<MainContent className="container grid content-start gap-y-8 py-8">
+			<PageTitle>{t("title")}</PageTitle>
+
+			<DashboardAdminSshompIngestContent />
+		</MainContent>
+	);
+}
+
+function DashboardAdminSshompIngestContent() {
+	return (
+		<section>
+			<AdminSshompIngestFormContent />
+		</section>
+	);
+}

--- a/components/admin/sshomp-ingest-form-content.tsx
+++ b/components/admin/sshomp-ingest-form-content.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useFormState } from "react-dom";
+
+import { SubmitButton } from "@/components/submit-button";
+import { Form } from "@/components/ui/form";
+import { FormError as FormErrorMessage } from "@/components/ui/form-error";
+import { FormSuccess as FormSuccessMessage } from "@/components/ui/form-success";
+import { ingestDataFromSshompAction } from "@/lib/actions/sshomp";
+import { createKey } from "@/lib/create-key";
+
+export function AdminSshompIngestFormContent(): ReactNode {
+	const [formState, formAction] = useFormState(ingestDataFromSshompAction, undefined);
+
+	return (
+		<Form
+			action={formAction}
+			className="grid gap-y-6"
+			validationErrors={formState?.status === "error" ? formState.fieldErrors : undefined}
+		>
+			<SubmitButton>Ingest</SubmitButton>
+
+			<FormSuccessMessage key={createKey("form-success", formState?.timestamp)}>
+				{formState?.status === "success" && formState.message.length > 0 ? formState.message : null}
+			</FormSuccessMessage>
+
+			<FormErrorMessage key={createKey("form-error", formState?.timestamp)}>
+				{formState?.status === "error" && formState.formErrors.length > 0
+					? formState.formErrors
+					: null}
+			</FormErrorMessage>
+		</Form>
+	);
+}

--- a/lib/actions/sshomp.ts
+++ b/lib/actions/sshomp.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { log } from "@acdh-oeaw/lib";
+import { revalidatePath } from "next/cache";
+import { getTranslations } from "next-intl/server";
+import type { z, ZodTypeAny } from "zod";
+
+import { ingestDataFromSshomp } from "@/lib/db/ingest-data-from-sshomp";
+
+interface FormReturnValue {
+	timestamp: number;
+}
+
+interface FormErrors extends FormReturnValue, z.typeToFlattenedError<ZodTypeAny> {
+	status: "error";
+}
+
+interface FormSuccess extends FormReturnValue {
+	status: "success";
+	message: string;
+}
+
+type FormState = FormErrors | FormSuccess;
+
+export async function ingestDataFromSshompAction(
+	previousFormState: FormState | undefined,
+	formData: FormData,
+): Promise<FormState> {
+	const t = await getTranslations("actions.ingestDataFromSshomp");
+
+	try {
+		const stats = await ingestDataFromSshomp();
+
+		revalidatePath("/[locale]/dashboard/admin/sshomp", "page");
+
+		return {
+			status: "success" as const,
+			message: t("success") + "\n" + JSON.stringify(stats), // TODO:
+			timestamp: Date.now(),
+		};
+	} catch (error) {
+		log.error(error);
+
+		return {
+			status: "error" as const,
+			formErrors: [t("errors.default")],
+			fieldErrors: {},
+			timestamp: Date.now(),
+		};
+	}
+}

--- a/lib/db/ingest-data-from-sshomp.ts
+++ b/lib/db/ingest-data-from-sshomp.ts
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { assert, createUrl, createUrlSearchParams, log, request } from "@acdh-oeaw/lib";
+
+import { env } from "@/config/env.config";
+import { db } from "@/lib/db";
+
+export async function ingestDataFromSshomp() {
+	const serviceSizeSmall = await db.serviceSize.findFirst({
+		where: {
+			type: "small",
+		},
+		select: {
+			id: true,
+		},
+	});
+	assert(serviceSizeSmall);
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const entries: Array<any> = [];
+	let page = 1;
+	let hasMorePages = false;
+
+	do {
+		const url = createUrl({
+			baseUrl: env.SSHOC_MARKETPLACE_API_BASE_URL,
+			pathname: "/api/item-search",
+			searchParams: createUrlSearchParams({
+				categories: "tool-or-service",
+				"f.keyword": "DARIAH Resource",
+				order: "label",
+				page,
+				perpage: 50,
+			}),
+		});
+
+		log.info(`Fetching page ${page}.`);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const data = (await request(url, { responseType: "json" })) as any;
+		log.info(`Processing ${data.count} entries.`);
+
+		entries.push(...data.items);
+		page++;
+		hasMorePages = page <= data.pages;
+	} while (hasMorePages);
+
+	const stats = {
+		software: { created: 0, updated: 0 },
+		services: { created: 0, updated: 0 },
+	};
+
+	for (const entry of entries) {
+		const id = entry.persistentId;
+
+		/** Entries in sshomp can have leading whitespace in label. */
+		const name = (entry.label as string).trim();
+
+		const unrEntry = await db.service.findFirst({
+			where: {
+				marketplaceId: id,
+			},
+			select: {
+				id: true,
+			},
+		});
+
+		// @ts-expect-error Missing types.
+		const reviewer = entry.contributors.find((contributor) => {
+			return contributor.role.code === "reviewer";
+		});
+
+		if (reviewer == null) {
+			log.warn(`No reviewer found for ${name}.`);
+			continue;
+		}
+
+		const actorId = reviewer.actor.id;
+		const country = await db.country.findFirst({
+			where: {
+				marketplaceId: actorId,
+			},
+			select: {
+				id: true,
+			},
+		});
+
+		if (country == null) {
+			log.warn(`Unknown actor id ${actorId}.`);
+			continue;
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const resourceType = entry.properties.find((property: any) => {
+			return property.type.code === "resource-category";
+		})?.concept?.label;
+
+		if (resourceType === "Software") {
+			if (unrEntry == null) {
+				await db.software.create({
+					data: {
+						name,
+						marketplaceId: id,
+						marketplaceStatus: "added_as_item",
+						status: "maintained",
+						countries: {
+							connect: {
+								id: country.id,
+							},
+						},
+					},
+				});
+
+				log.info(`Created software "${name}".`);
+				stats.software.created++;
+			} else {
+				await db.software.update({
+					where: {
+						id: unrEntry.id,
+					},
+					data: {
+						name,
+						marketplaceId: id,
+						marketplaceStatus: "added_as_item",
+						status: "maintained",
+						countries: {
+							connect: {
+								id: country.id,
+							},
+						},
+					},
+				});
+
+				log.info(`Updated software "${name}".`);
+				stats.software.updated++;
+			}
+		} else {
+			if (unrEntry == null) {
+				await db.service.create({
+					data: {
+						name,
+						marketplaceId: id,
+						marketplaceStatus: "yes",
+						status: "live",
+						countries: {
+							connect: {
+								id: country.id,
+							},
+						},
+						size: {
+							connect: {
+								id: serviceSizeSmall.id,
+							},
+						},
+					},
+				});
+
+				log.info(`Created service "${name}".`);
+				stats.services.created++;
+			} else {
+				await db.service.update({
+					where: {
+						id: unrEntry.id,
+					},
+					data: {
+						name,
+						marketplaceId: id,
+						marketplaceStatus: "yes",
+						status: "live",
+						countries: {
+							connect: {
+								id: country.id,
+							},
+						},
+						size: {
+							connect: {
+								id: serviceSizeSmall.id,
+							},
+						},
+					},
+				});
+
+				log.info(`Updated service "${name}".`);
+				stats.services.updated++;
+			}
+		}
+	}
+
+	return stats;
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -75,6 +75,12 @@
 		},
 		"title": "Institutionen"
 	},
+	"DashboardAdminSshompIngestPage": {
+		"meta": {
+			"title": "SSH Open Marketplace Import"
+		},
+		"title": "SSH Open Marketplace Import"
+	},
 	"DashboardAdminUsersPage": {
 		"meta": {
 			"title": "Benutzer*innen"
@@ -199,6 +205,12 @@
 				"default": "Konnte Outreach nicht erstellen."
 			},
 			"success": "Outreach erfolgreich erstellt."
+		},
+		"ingestDataFromSshomp": {
+			"errors": {
+				"default": "Konnte Software und Services nicht importieren."
+			},
+			"success": "Software und Services erfolgreich importiert."
 		},
 		"sendEmail": {
 			"errors": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -75,6 +75,12 @@
 		},
 		"title": "Institutions"
 	},
+	"DashboardAdminSshompIngestPage": {
+		"meta": {
+			"title": "SSH Open Marketplace import"
+		},
+		"title": "SSH Open Marketplace import"
+	},
 	"DashboardAdminUsersPage": {
 		"meta": {
 			"title": "Users"
@@ -199,6 +205,12 @@
 				"default": "Could not create outreach."
 			},
 			"success": "Successfully created outreach."
+		},
+		"ingestDataFromSshomp": {
+			"errors": {
+				"default": "Could not import software and services."
+			},
+			"success": "Successfully imported software and services."
 		},
 		"sendEmail": {
 			"errors": {


### PR DESCRIPTION
this adds a new admin dashboard page to ingest software and services from the ssh open marketplace.

note that for this to work, sshomp actor ids need to be associated with countries in the unr database. this is what the `prisma/create-country-ids-from-sshomp.ts` script does.