### PR TITLE
docs: add middleware rewrite from /documentation to /documentation/guidelines

### DIFF
--- a/content/documentation/data-model.mdx
+++ b/content/documentation/data-model.mdx
@@ -3,6 +3,6 @@ title: Data model
 ---
 This is the data model for DARIAH Unified National Reporting:
 
-![entity relationship diagram of the dariah unr data model](/assets/images/content/documentation/data-model/data-model.svg)
+![entity relationship diagram of the dariah unr data model](/assets/content/documentation/data-model/data-model.svg)
 
 You can view an editable version [with dbdiagram.io](https://dbdiagram.io/d/DARIAH-UNR-65d486e0ac844320ae90baa9).

--- a/content/documentation/guidelines.mdx
+++ b/content/documentation/guidelines.mdx
@@ -33,7 +33,7 @@ Any events held at the national level that contribute to DARIAH in your country 
 
 * DARIAH Commissioned Event are big, international events that are commissioned by DARIAH and serve to fulfill a strategic interest. Examples include the Annual Event or the DARIAH Innovation Forum.
 
-***Numbers of events provided will be used to help determine the national in-kind contributions as well.***
+**Numbers of events provided will be used to help determine the national in-kind contributions as well.**
 
 ## Number of interactions via Outreach
 
@@ -65,13 +65,13 @@ Several units can be used to capture these interactions:
 
 * watch\_time
 
-***Declaration of at least one national website and one social media channel will be used to help determine the national in-kind contributions as well.***
+**Declaration of at least one national website and one social media channel will be used to help determine the national in-kind contributions as well.**
 
 ## Number of Interactions via Services
 
 ### Updating your national service list
 
-Services in this list are the ones included in your national catalogue, as[ maintained in the SSH Open Marketplace](https://marketplace.sshopencloud.eu/search?f.keyword=DARIAH+Resource), and displayed on the[ DARIAH service catalogue](https://www.dariah.eu/tools-services/tools-and-services/). If you want to update the list, **please refer to**[** these guidelines**](https://drive.google.com/file/d/10tGdjKY8XC3TkNnVD_svl9_VrPoWTBWw/view).
+Services in this list are the ones included in your national catalogue, as [maintained in the SSH Open Marketplace](https://marketplace.sshopencloud.eu/search?f.keyword=DARIAH+Resource), and displayed on the [DARIAH service catalogue](https://www.dariah.eu/tools-services/tools-and-services/). If you want to update the list, **please refer to** [**these guidelines**](https://drive.google.com/file/d/10tGdjKY8XC3TkNnVD_svl9_VrPoWTBWw/view).
 
 Please note that if you are adding resources to the Marketplace, they may not immediately appear in this tool. If this is the case, once you have made additions, or if you have any questions, please contact the UNR team.
 
@@ -107,13 +107,13 @@ Like services, software developed within the DARIAH national consortia should be
 
 In distinction to services, which are available as web applications or APIs and can be used directly, software needs to be downloaded and installed or executed on the side of the user, to be used. The contribution should include the source code (and must be documented as well, not just orphan code). The code can be in any programming language, it can also be only a simple script dedicated to one specific task, as long as it is working and documented.
 
-*No KPIs nor in-kind contributions calculations are attached to the software declarations. However your software list is compiled and included in your national tools\&services catalogue.*
+*No KPIs nor in-kind contributions calculations are attached to the software declarations. However your software list is compiled and included in your national tools and services catalogue.*
 
 ## Number of publications
 
 The DARIAH definition of a publication is a significant and durable, accessible contribution to knowledge. A publication counts as DARIAH-affiliated when
 
-* it resulted from work in the national consortium; funded by either DARIAH-EU or your national funding for DARIAHs/ CLARIAH
+* it resulted from work in the national consortium; funded by either DARIAH-EU or your national funding for DARIAHs/CLARIAH
 
 * a DARIAH-affiliated tool or resource is cited in them;
 
@@ -123,7 +123,7 @@ The DARIAH definition of a publication is a significant and durable, accessible 
 
 They may be peer reviewed publications, or they may be reports,working papers, pre-prints, major releases of training material or even substantive blog posts. Importantly, please also include DOIs or [other Persistent Identifiers (handles, HAL IDs etc.](https://project-thor.readme.io/docs/project-glossary)) when reporting the bibliographical entries. You also do not need to report items deposited into DARIAH-EU HAL or Zenodo collections, as these are already automatically gathered.
 
-**To add your publications to the **[**DARIAH Zotero library**](https://www.zotero.org/groups/744474/dariah/library)**, please consult the **[**Guidelines “How to declare your DARIAH publications in Zotero?”**](https://drive.google.com/file/d/1ghBEwE6d3xJU8urxO1djhhdieiM9qOY2/view?usp=sharing)**.**
+**To add your publications to the **[**DARIAH Zotero library**](https://www.zotero.org/groups/744474/dariah/library)**, please consult the **[**Guidelines "How to declare your DARIAH publications in Zotero?"**](https://drive.google.com/file/d/1ghBEwE6d3xJU8urxO1djhhdieiM9qOY2/view?usp=sharing)**.**
 
 *The total number of publications you report each year is used as a KPI but not included in the in-kind contribution calculation.*
 
@@ -137,7 +137,7 @@ This KPI covers the overall amount in Euros of any grant funding awarded to or w
 
 **How is a DARIAH national in-kind contribution calculated?**
 
-Every DARIAH Member country must reach a certain threshold of contributions, set by the DARIAH General Assembly. In the past, National Coordinators were asked to calculate these sums by themselves. However, in line with the requests from National Coordinators and the ongoing reforms to contributions, we have decided to offer guidelines that allow In-Kind Contributions to be automatically calculated, following input to the Unified National Report. **For further information, please read the**[** Policy on the financial value of DARIAH services and other IKCs**](https://docs.google.com/document/d/1A482x5XHwOsEZlmOcn5hw7lHy9muKMfeNs_T5BzQ4II/edit)**.**
+Every DARIAH Member country must reach a certain threshold of contributions, set by the DARIAH General Assembly. In the past, National Coordinators were asked to calculate these sums by themselves. However, in line with the requests from National Coordinators and the ongoing reforms to contributions, we have decided to offer guidelines that allow In-Kind Contributions to be automatically calculated, following input to the Unified National Report. **For further information, please read the **[**Policy on the financial value of DARIAH services and other IKCs**](https://docs.google.com/document/d/1A482x5XHwOsEZlmOcn5hw7lHy9muKMfeNs_T5BzQ4II/edit)**.**
 
 In case of questions, please [contact the DARIAH DCO team](/contact).
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,7 @@ import createI18nMiddleware from "next-intl/middleware";
 
 import { defaultLocale, locales } from "@/config/i18n.config";
 import { config as authConfig } from "@/lib/auth/config";
+import { getNormalizedPathname } from "@/lib/get-normalized-pathname";
 
 /**
  * Next.js currently only supports the "edge" runtime in middleware, which is not
@@ -16,15 +17,20 @@ const i18nMiddleware = createI18nMiddleware({
 	locales,
 });
 
-export default authMiddleware((req) => {
+export default authMiddleware((request) => {
+	const pathname = getNormalizedPathname(request.nextUrl.pathname);
+	if (pathname === "/documentation") {
+		request.nextUrl.pathname += "/guidelines";
+	}
+
 	/**
 	 * Don't add locale prefixes to api routes (in case they are included in the
 	 * middleware `matcher` config).
 	 */
-	if (req.nextUrl.pathname.startsWith("/api/")) return;
+	if (request.nextUrl.pathname.startsWith("/api/")) return;
 
 	// eslint-disable-next-line consistent-return
-	return i18nMiddleware(req);
+	return i18nMiddleware(request);
 });
 
 export const config: MiddlewareConfig = {

--- a/next.config.js
+++ b/next.config.js
@@ -28,29 +28,6 @@ const config = {
 	},
 	output: env.BUILD_MODE,
 	pageExtensions: ["ts", "tsx", "md", "mdx"],
-	redirects() {
-		/** @type {Awaited<ReturnType<NonNullable<NextConfig["redirects"]>>>} */
-		const redirects = ["de", "en"].map((locale) => {
-			return {
-				source: "/documentation",
-				destination: "/documentation/guidelines",
-				permanent: false,
-			};
-		});
-
-		return Promise.resolve(redirects);
-	},
-	rewrites() {
-		/** @type {Awaited<ReturnType<NonNullable<NextConfig["rewrites"]>>>} */
-		const rewrites = [
-			{
-				source: "/cms",
-				destination: "/keystatic",
-			},
-		];
-
-		return Promise.resolve(rewrites);
-	},
 	typescript: {
 		ignoreBuildErrors: true,
 	},


### PR DESCRIPTION
this removes the redirects from `next.config.js`, which were not working, and adds a rewrite via middleware from `/documentation` to `/documentation/guidelines`.