### PR TITLE
fix: directly link to guidelines instead of using rewrites

### DIFF
--- a/app/[locale]/(index)/page.tsx
+++ b/app/[locale]/(index)/page.tsx
@@ -68,7 +68,7 @@ function IndexPageHeroSection(): ReactNode {
 				<LinkButton href={createHref({ pathname: "/dashboard" })}>
 					{t("go-to-dashboard")}
 				</LinkButton>
-				<LinkButton href={createHref({ pathname: "/documentation" })} variant="outline">
+				<LinkButton href={createHref({ pathname: "/documentation/guidelines" })} variant="outline">
 					{t("read-documentation")}
 				</LinkButton>
 			</div>

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -26,7 +26,7 @@ export function AppHeader(): ReactNode {
 			label: t("links.dashboard"),
 		},
 		documentation: {
-			href: createHref({ pathname: "/documentation" }),
+			href: createHref({ pathname: "/documentation/guidelines" }),
 			label: t("links.documentation"),
 		},
 	} satisfies Record<string, { href: LinkProps["href"]; label: string }>;

--- a/middleware.ts
+++ b/middleware.ts
@@ -18,11 +18,6 @@ const i18nMiddleware = createI18nMiddleware({
 });
 
 export default authMiddleware((request) => {
-	const pathname = getNormalizedPathname(request.nextUrl.pathname);
-	if (pathname === "/documentation") {
-		request.nextUrl.pathname += "/guidelines";
-	}
-
 	/**
 	 * Don't add locale prefixes to api routes (in case they are included in the
 	 * middleware `matcher` config).


### PR DESCRIPTION
this removes the rewrite for `/documentation` pages, and instead directly links to the guidelines.