### PR TITLE
docs: update link to google doc

### DIFF
--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -459,7 +459,7 @@ async function DashboardCountryReportEditStepPageContent(
 								DARIAH service catalogue
 							</a>
 							. If you want to update the list, please refer to{" "}
-							<a href="https://drive.google.com/file/d/10tGdjKY8XC3TkNnVD_svl9_VrPoWTBWw/view">
+							<a href="https://drive.google.com/file/d/1l7sS4lAzbFgkY9etqwGxEBQP3C8jyn_I/view">
 								these guidelines
 							</a>
 							.

--- a/content/documentation/guidelines.mdx
+++ b/content/documentation/guidelines.mdx
@@ -71,7 +71,7 @@ Several units can be used to capture these interactions:
 
 ### Updating your national service list
 
-Services in this list are the ones included in your national catalogue, as [maintained in the SSH Open Marketplace](https://marketplace.sshopencloud.eu/search?f.keyword=DARIAH+Resource), and displayed on the [DARIAH service catalogue](https://www.dariah.eu/tools-services/tools-and-services/). If you want to update the list, **please refer to** [**these guidelines**](https://drive.google.com/file/d/10tGdjKY8XC3TkNnVD_svl9_VrPoWTBWw/view).
+Services in this list are the ones included in your national catalogue, as [maintained in the SSH Open Marketplace](https://marketplace.sshopencloud.eu/search?f.keyword=DARIAH+Resource), and displayed on the [DARIAH service catalogue](https://www.dariah.eu/tools-services/tools-and-services/). If you want to update the list, **please refer to** [**these guidelines**](https://drive.google.com/file/d/1l7sS4lAzbFgkY9etqwGxEBQP3C8jyn_I/view).
 
 Please note that if you are adding resources to the Marketplace, they may not immediately appear in this tool. If this is the case, once you have made additions, or if you have any questions, please contact the UNR team.
 


### PR DESCRIPTION
this updates the link to the google doc explaining how to add/update/delete items from the ssh open marketplace.