### PR TITLE
fix: only list maintained software and live services

### DIFF
--- a/lib/data/service.ts
+++ b/lib/data/service.ts
@@ -16,9 +16,7 @@ export function getServicesByCountry(params: GetServicesByCountryParams) {
 					id: countryId,
 				},
 			},
-			status: {
-				not: "discontinued",
-			},
+			status: "live",
 		},
 		orderBy: {
 			name: "asc",

--- a/lib/data/software.ts
+++ b/lib/data/software.ts
@@ -16,9 +16,7 @@ export function getSoftwareByCountry(params: GetSoftwareByCountryParams) {
 					id: countryId,
 				},
 			},
-			status: {
-				not: "not_maintained",
-			},
+			status: "maintained",
 		},
 		orderBy: {
 			name: "asc",


### PR DESCRIPTION
this changes the list of software and services to only include software with status "maintained" (i.e. not show "needs_review" software"), and only show services with status "live" (instead of those which are not marked as "discontinued").