### PR TITLE
fix: keep software and service status when updating from sshomp

### DIFF
--- a/lib/db/ingest-data-from-sshomp.ts
+++ b/lib/db/ingest-data-from-sshomp.ts
@@ -130,8 +130,8 @@ export async function ingestDataFromSshomp() {
 					data: {
 						name,
 						marketplaceId: id,
-						marketplaceStatus: "added_as_item",
-						status: "maintained",
+						// marketplaceStatus: "added_as_item",
+						// status: "maintained",
 						countries: {
 							connect: countries.map((country) => {
 								return { id: country.id };
@@ -183,8 +183,8 @@ export async function ingestDataFromSshomp() {
 					data: {
 						name,
 						marketplaceId: id,
-						marketplaceStatus: "yes",
-						status: "live",
+						// marketplaceStatus: "yes",
+						// status: "live",
 						countries: {
 							connect: countries.map((country) => {
 								return { id: country.id };

--- a/prisma/create-initial-entries-from-sshomp.ts
+++ b/prisma/create-initial-entries-from-sshomp.ts
@@ -126,8 +126,8 @@ async function createEntriesFromSshomp() {
 					data: {
 						name,
 						marketplaceId: id,
-						marketplaceStatus: "added_as_item",
-						status: "maintained",
+						// marketplaceStatus: "added_as_item",
+						// status: "maintained",
 						countries: {
 							connect: countries.map((country) => {
 								return { id: country.id };
@@ -179,8 +179,8 @@ async function createEntriesFromSshomp() {
 					data: {
 						name,
 						marketplaceId: id,
-						marketplaceStatus: "yes",
-						status: "live",
+						// marketplaceStatus: "yes",
+						// status: "live",
 						countries: {
 							connect: countries.map((country) => {
 								return { id: country.id };


### PR DESCRIPTION
this ensures we keep any software and services status when importing data from the ssh open marketplace. when creating new software, we set `status: "maintained"`, and `marketplaceStatus: "added_as_item"`, and when creating new services, we set `status: "live"` and `marketplaceStatus: "yes"`