### PR TITLE
fix: support loading indicator in server components

### DIFF
--- a/components/loading-indicator.tsx
+++ b/components/loading-indicator.tsx
@@ -1,9 +1,9 @@
-import { useLabels } from "@react-aria/utils";
 import type { AriaLabelingProps, DOMProps } from "@react-types/shared";
 import { Loader2Icon } from "lucide-react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { cn } from "@/lib/styles";
+import { useLabels } from "@/lib/use-labels";
 
 interface LoadingIndicatorProps
 	extends AriaLabelingProps,
@@ -18,10 +18,12 @@ export function LoadingIndicator(props: LoadingIndicatorProps): ReactNode {
 		labelingProps["aria-label"] != null || labelingProps["aria-labelledby"] != null;
 
 	return (
-		<Loader2Icon
-			{...labelingProps}
-			aria-hidden={hasLabeling ? ariaHidden ?? undefined : true}
-			className={cn("animate-spin", className)}
-		/>
+		<div className={cn("delay-500 duration-500 animate-in fade-in fill-mode-both", className)}>
+			<Loader2Icon
+				{...labelingProps}
+				aria-hidden={hasLabeling ? ariaHidden ?? undefined : true}
+				className="animate-spin"
+			/>
+		</div>
 	);
 }

--- a/lib/use-id.ts
+++ b/lib/use-id.ts
@@ -1,0 +1,7 @@
+import { useId as _useId } from "react";
+
+export function useId(defaultId?: string): string {
+	const id = _useId();
+
+	return defaultId ?? id;
+}

--- a/lib/use-labels.ts
+++ b/lib/use-labels.ts
@@ -1,0 +1,38 @@
+import type { AriaLabelingProps, DOMProps } from "@react-types/shared";
+
+import { useId } from "@/lib/use-id";
+
+/**
+ * Copied from `react-aria`, because it currently does not work in server components.
+ *
+ * @see https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/utils/src/useLabels.ts
+ */
+export function useLabels(
+	props: AriaLabelingProps & DOMProps,
+	defaultLabel?: string,
+): AriaLabelingProps & DOMProps {
+	let { id, "aria-label": label, "aria-labelledby": labelledBy } = props;
+
+	/**
+	 * If there is both an aria-label and aria-labelledby, combine them by pointing
+	 * to the element itself.
+	 */
+	id = useId(id);
+	if (labelledBy && label) {
+		const ids = new Set([id, ...labelledBy.trim().split(/\s+/)]);
+		labelledBy = [...ids].join(" ");
+	} else if (labelledBy) {
+		labelledBy = labelledBy.trim().split(/\s+/).join(" ");
+	}
+
+	/** If no labels are provided, use the default. */
+	if (!label && !labelledBy && defaultLabel) {
+		label = defaultLabel;
+	}
+
+	return {
+		id,
+		"aria-label": label,
+		"aria-labelledby": labelledBy,
+	};
+}


### PR DESCRIPTION
this replaces `useLabels` from `@react-aria` with our own implementation in order to support the loading indicator component in server components. while `@react-aria/utils#useLabels` does not directly depend on client-only functionality, the way react-aria is currently bundled means it pulls in react context, which only works in client components.