### PR TITLE
refactor: move workaround for next-intl types issue

### DIFF
--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -84,8 +84,6 @@ async function DashboardPageContent() {
 
 	if (user == null) {
 		redirect("/");
-		/** FIXME: @see https://github.com/amannn/next-intl/issues/823 */
-		assert(false);
 	}
 
 	const year = new Date().getUTCFullYear() - 1;

--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/edit/[step]/page.tsx
@@ -129,8 +129,6 @@ async function DashboardCountryReportEditStepPageContent(
 
 	if (user == null) {
 		redirect("/");
-		/** FIXME: @see https://github.com/amannn/next-intl/issues/823 */
-		assert(false);
 	}
 
 	const country = await getCountryByCode({ code });

--- a/app/[locale]/dashboard/reports/[year]/countries/[code]/page.tsx
+++ b/app/[locale]/dashboard/reports/[year]/countries/[code]/page.tsx
@@ -98,8 +98,6 @@ async function DashboardCountryReportPageContent(props: DashboardCountryReportPa
 
 	if (user == null) {
 		redirect("/");
-		/** FIXME: @see https://github.com/amannn/next-intl/issues/823 */
-		assert(false);
 	}
 
 	const report = await getReportByCountryCode({ countryCode: code, year });

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -5,9 +5,17 @@ import type { ComponentPropsWithRef, FC } from "react";
 
 import { isValidLocale, type Locale, locales } from "@/config/i18n.config";
 
-const { Link, redirect, usePathname, useRouter } = createSharedPathnamesNavigation({
+const {
+	Link,
+	redirect: __redirect,
+	usePathname,
+	useRouter,
+} = createSharedPathnamesNavigation({
 	locales,
 });
+
+/** FIXME: @see https://github.com/amannn/next-intl/issues/823 */
+const redirect: typeof __redirect = __redirect;
 
 export { redirect, usePathname, useRouter };
 


### PR DESCRIPTION
this applies a different workaround for a type issue with `redirect` from `next-intl`. see the github issue linked in the comment for more info.