### PR TITLE
test: check opengraph image content type in e2e test

### DIFF
--- a/config/auth.config.ts
+++ b/config/auth.config.ts
@@ -1,13 +1,13 @@
 export const publicRoutes: Array<RegExp | string> = [
+	"/",
+	new RegExp("^/api/.*"),
 	/** Auth routes are always treated as public. */
 	// new RegExp("^/auth/.*"),
-	new RegExp("^/api/.*"),
-	"/",
 	"/contact",
+	new RegExp("^/documentation(/.*)?"),
 	"/imprint",
+	"/keystatic",
+	"/opengraph-image",
 	"/privacy-policy",
 	"/terms-of-use",
-	"/cms",
-	"/keystatic",
-	new RegExp("^/documentation(/.*)?"),
 ];

--- a/e2e/tests/app/metadata.test.ts
+++ b/e2e/tests/app/metadata.test.ts
@@ -150,11 +150,23 @@ test.describe("should add json+ld metadata", () => {
 	});
 });
 
-test("should serve an open-graph image", async ({ request }) => {
+test("should serve an open-graph image", async ({ page, request }) => {
 	for (const locale of locales) {
-		const response = await request.get(`/${locale}/opengraph-image.png`);
-		const status = response.status();
+		const imagePath = `/${locale}/opengraph-image`;
 
-		expect(status).toEqual(200);
+		await page.goto(`/${locale}`);
+		await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+			"content",
+			expect.stringContaining(
+				String(createUrl({ baseUrl: env.NEXT_PUBLIC_APP_BASE_URL, pathname: imagePath })) + `?`,
+			),
+		);
+
+		const response = await request.get(imagePath);
+		const status = response.status();
+		const contentType = response.headers()["content-type"];
+
+		expect(status).toBe(200);
+		expect(contentType).toBe("image/png");
 	}
 });


### PR DESCRIPTION
this improves the e2e test for opengraph images, to (i) check the content-type, and (ii) ensure a `<meta>` tag is added.