### PR TITLE
feat: add pagination to software and services admin dashboard tables

### DIFF
--- a/components/admin/pagination.tsx
+++ b/components/admin/pagination.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
+import type { usePagination } from "@/components/admin/use-pagination";
+import { IconButton } from "@/components/ui/icon-button";
+import { createKey } from "@/lib/create-key";
+
+interface PaginationProps {
+	pagination: ReturnType<typeof usePagination>;
+}
+
+export function Pagination(props: PaginationProps) {
+	const { pagination } = props;
+
+	return (
+		<ul className="flex gap-x-1">
+			<li>
+				<IconButton
+					isDisabled={pagination.currentPage === 1}
+					onPress={() => {
+						pagination.setCurrentPage((page) => {
+							if (page > 1) return page - 1;
+							return page;
+						});
+					}}
+				>
+					<ChevronLeftIcon className="size-4 shrink-0" />
+				</IconButton>
+			</li>
+
+			{pagination.links.map((link, index) => {
+				if (link.type === "ellipsis") {
+					return <span key={createKey(link.type, index)}>...</span>;
+				}
+
+				return (
+					<li key={link.page}>
+						<IconButton
+							isDisabled={link.page === pagination.currentPage}
+							onPress={() => {
+								pagination.setCurrentPage(link.page);
+							}}
+						>
+							<span>{link.page}</span>
+						</IconButton>
+					</li>
+				);
+			})}
+
+			<li>
+				<IconButton
+					isDisabled={pagination.currentPage === pagination.pages}
+					onPress={() => {
+						pagination.setCurrentPage((page) => {
+							if (page < pagination.pages) return page + 1;
+							return page;
+						});
+					}}
+				>
+					<ChevronRightIcon className="size-4 shrink-0" />
+				</IconButton>
+			</li>
+		</ul>
+	);
+}

--- a/components/admin/services-table-content.tsx
+++ b/components/admin/services-table-content.tsx
@@ -17,6 +17,8 @@ import { Fragment, type ReactNode, useId, useMemo, useState } from "react";
 import type { Key } from "react-aria-components";
 import { useFormState } from "react-dom";
 
+import { Pagination } from "@/components/admin/pagination";
+import { usePagination } from "@/components/admin/use-pagination";
 import { SubmitButton } from "@/components/submit-button";
 import {
 	DropdownMenu,
@@ -150,6 +152,8 @@ export function AdminServicesTableContent(props: AdminServicesTableContentProps)
 		return items;
 	}, [services, sortDescriptor, countriesById]);
 
+	const pagination = usePagination({ items });
+
 	return (
 		<Fragment>
 			<div className="flex justify-end">
@@ -161,6 +165,10 @@ export function AdminServicesTableContent(props: AdminServicesTableContentProps)
 					<PlusIcon aria-hidden={true} className="size-5 shrink-0" />
 					<span>Create</span>
 				</Button>
+			</div>
+
+			<div className="flex justify-end">
+				<Pagination pagination={pagination} />
 			</div>
 
 			<Table
@@ -191,7 +199,7 @@ export function AdminServicesTableContent(props: AdminServicesTableContentProps)
 						Actions
 					</Column>
 				</TableHeader>
-				<TableBody items={items}>
+				<TableBody items={pagination.currentItems}>
 					{(row) => {
 						function onAction(key: Key) {
 							switch (key) {
@@ -248,6 +256,10 @@ export function AdminServicesTableContent(props: AdminServicesTableContentProps)
 					}}
 				</TableBody>
 			</Table>
+
+			<div className="flex justify-end">
+				<Pagination pagination={pagination} />
+			</div>
 
 			<CreateServicesDialog
 				key={createKey("create-service", action?.item?.id)}

--- a/components/admin/software-table-content.tsx
+++ b/components/admin/software-table-content.tsx
@@ -12,6 +12,8 @@ import { Fragment, type ReactNode, useId, useMemo, useState } from "react";
 import type { Key } from "react-aria-components";
 import { useFormState } from "react-dom";
 
+import { Pagination } from "@/components/admin/pagination";
+import { usePagination } from "@/components/admin/use-pagination";
 import { SubmitButton } from "@/components/submit-button";
 import {
 	DropdownMenu,
@@ -116,6 +118,8 @@ export function AdminSoftwareTableContent(props: AdminSoftwareTableContentProps)
 		return items;
 	}, [software, sortDescriptor, countriesById]);
 
+	const pagination = usePagination({ items });
+
 	return (
 		<Fragment>
 			<div className="flex justify-end">
@@ -127,6 +131,10 @@ export function AdminSoftwareTableContent(props: AdminSoftwareTableContentProps)
 					<PlusIcon aria-hidden={true} className="size-5 shrink-0" />
 					<span>Create</span>
 				</Button>
+			</div>
+
+			<div className="flex justify-end">
+				<Pagination pagination={pagination} />
 			</div>
 
 			<Table
@@ -214,6 +222,10 @@ export function AdminSoftwareTableContent(props: AdminSoftwareTableContentProps)
 					}}
 				</TableBody>
 			</Table>
+
+			<div className="flex justify-end">
+				<Pagination pagination={pagination} />
+			</div>
 
 			<CreateSoftwareDialog
 				key={createKey("create-software", action?.item?.id)}

--- a/components/admin/use-pagination.ts
+++ b/components/admin/use-pagination.ts
@@ -1,0 +1,23 @@
+import { createPagination } from "@acdh-oeaw/lib";
+import { useMemo, useState } from "react";
+
+interface UsePaginationParams<T> {
+	items: Array<T>;
+	initialPage?: number;
+}
+
+export function usePagination<T>(params: UsePaginationParams<T>) {
+	const { initialPage = 1, items } = params;
+
+	const [currentPage, setCurrentPage] = useState(initialPage);
+
+	const pagination = useMemo(() => {
+		const pageSize = 50;
+		const pages = Math.ceil(items.length / pageSize);
+		const currentItems = items.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+		const links = createPagination({ page: currentPage, pages });
+		return { pages, pageSize, currentPage, currentItems, links, setCurrentPage };
+	}, [items, currentPage, setCurrentPage]);
+
+	return pagination;
+}


### PR DESCRIPTION
this adds pagination to software and services admin dashboard tables. this should also improve the table lagginess a bit, which was pretty bad for the services table with ~350 rows. reconsider this once react-aria's table has virtualisation support. current page size is 50 rows, pagination state is currently not synced to url search params.