### PR TITLE
fix: avoid re-setting service size on sshomp import

### DIFF
--- a/lib/db/ingest-data-from-sshomp.ts
+++ b/lib/db/ingest-data-from-sshomp.ts
@@ -190,11 +190,11 @@ export async function ingestDataFromSshomp() {
 								return { id: country.id };
 							}),
 						},
-						size: {
-							connect: {
-								id: serviceSizeSmall.id,
-							},
-						},
+						// size: {
+						// 	connect: {
+						// 		id: serviceSizeSmall.id,
+						// 	},
+						// },
 					},
 				});
 

--- a/prisma/create-initial-entries-from-sshomp.ts
+++ b/prisma/create-initial-entries-from-sshomp.ts
@@ -186,11 +186,11 @@ async function createEntriesFromSshomp() {
 								return { id: country.id };
 							}),
 						},
-						size: {
-							connect: {
-								id: serviceSizeSmall.id,
-							},
-						},
+						// size: {
+						// 	connect: {
+						// 		id: serviceSizeSmall.id,
+						// 	},
+						// },
 					},
 				});
 				log.info(`Updated service "${name}".`);


### PR DESCRIPTION
this fixes a bug in the sshomp import script which reset the service size when updating an existing service.