### PR TITLE
fix: display institution types, and list national_coordinating_institutions

### DIFF
--- a/components/forms/institutions-form-content.tsx
+++ b/components/forms/institutions-form-content.tsx
@@ -66,7 +66,7 @@ export function InstitutionsFormContent(props: InstitutionsFormContentProps): Re
 					return (
 						<Group
 							key={institution.id}
-							className="grid content-start gap-x-4 gap-y-3 sm:grid-cols-[1fr_auto]"
+							className="grid content-start gap-x-4 gap-y-3 sm:grid-cols-[1fr_auto_auto]"
 						>
 							<input name={`institutions.${index}.id`} type="hidden" value={institution.id} />
 
@@ -75,6 +75,13 @@ export function InstitutionsFormContent(props: InstitutionsFormContentProps): Re
 								isReadOnly={true}
 								label="Name"
 								name={`institutions.${index}.name`}
+							/>
+
+							<TextInputField
+								defaultValue={institution.types.join(", ")}
+								isReadOnly={true}
+								label="Type"
+								// name={`institutions.${index}.types`}
 							/>
 
 							<RadioGroupField

--- a/lib/data/institution.ts
+++ b/lib/data/institution.ts
@@ -40,7 +40,10 @@ export function getPartnerInstitutionsByCountry(params: GetPartnerInstitutionsBy
 			},
 			endDate: null,
 			types: {
-				has: InstitutionType.partner_institution,
+				hasSome: [
+					InstitutionType.partner_institution,
+					InstitutionType.national_coordinating_institution,
+				],
 			},
 		},
 		orderBy: {


### PR DESCRIPTION
this adjusts the institutions reporting page to also list institutions of type "national_coordinating_institution", and adds a separate readonly textinput for institution type.

note that in most cases, "national_coordinating_institution" institutions will also be "partner_institution"s - but there is one edgecase in in switzerland where "Dasch" is a national coordinating institution but not (yet) a partner institution.