### PR TITLE
fix: handle multiple resource types in sshomp ingest script

### DIFF
--- a/prisma/create-initial-entries-from-sshomp.ts
+++ b/prisma/create-initial-entries-from-sshomp.ts
@@ -84,12 +84,17 @@ async function createEntriesFromSshomp() {
 			continue;
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const resourceType = entry.properties.find((property: any) => {
-			return property.type.code === "resource-category";
-		})?.concept?.label;
+		const resourceTypes = entry.properties
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			.filter((property: any) => {
+				return property.type.code === "resource-category";
+			})
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			.map((property: any) => {
+				return property.concept.label as string;
+			});
 
-		if (resourceType === "Software") {
+		if (resourceTypes.includes("Software")) {
 			const software = await db.software.findFirst({
 				where: {
 					/**


### PR DESCRIPTION
the script ingesting data from the ssh open marketplace did not correctly handle the case where an item had multiple "resource type" properties. these are used at ingest time to differentiate between software and service (the sshomp lists both as "tools and services" entity type).

we also add a log to list software items, which had previously been added to the services table.